### PR TITLE
feat(android): Implement orphaned process cleaner

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,16 +780,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -811,9 +801,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -824,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -1336,21 +1326,12 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1363,12 +1344,6 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2605,23 +2580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,48 +2967,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4506,7 +4426,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -4625,25 +4545,12 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4956,7 +4863,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types 0.5.0",
+ "foreign-types",
  "js-sys",
  "log",
  "objc2 0.5.2",
@@ -5173,7 +5080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -5669,16 +5576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,9 +5593,7 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "tokio",
- "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -5903,7 +5798,6 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.1",
  "sha1",
  "thiserror 2.0.12",
@@ -6069,12 +5963,6 @@ name = "value-bag"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,8 +36,6 @@ wg = { version = "0.9.2", features = ["future"] }
 
 # Build profile for release: optimize for size
 [profile.release]
-opt-level = "z"      # Optimize for size
+opt-level = "s"      # Optimize for size
 lto = true             # Enable Link Time Optimization
-codegen-units = 1    # Slower builds, but better optimization
-panic = "abort"      # Abort on panic to reduce binary size
 strip = true           # Strip symbols from the final binary

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0.98"
 log = { version = "0.4.27", features = ["std"] }
 tauri-plugin-log = "2.6.0"
 futures-util = "0.3.31"
-tokio-tungstenite = { version = "0.27.0", features = ["native-tls", "handshake"] }
+tokio-tungstenite = { version = "0.27.0", features = ["handshake"] }
 # chrono = { version = "0.4.41", features = ["serde"] }
 polars = { version = "0.49.1", default-features = false, features = ["lazy", "sql"] }
 tokio = { version = "1.46.1", features = ["rt-multi-thread", "macros", "sync", "time", "process", "signal"] }

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use anyhow::{Error, Result, anyhow};
 use log::{error, info};
 #[cfg(not(target_os = "windows"))]
@@ -5,13 +6,14 @@ use nix::sys::signal::{Signal, kill as send_signal};
 #[cfg(not(target_os = "windows"))]
 use nix::unistd::Pid;
 use sha2::{Digest, Sha256};
-use std::fs;
+use std::{fs, process};
 use std::io::Write;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
+use futures_util::future;
 use tokio::process::{Child, Command}; // Use Tokio's Command and Child
 use tokio::sync::watch;
 
@@ -22,7 +24,7 @@ fn get_cli_binary_name() -> String {
         let mut hasher = Sha256::new();
         hasher.update(get_ecapture_bytes());
         let hash_string = hex::encode(hasher.finalize());
-        return format!("android_ecapture_x86_64_{}", hash_string);
+        return format!("android_ecapture_amd64_{}", hash_string);
     }
 
     // Android arm64
@@ -40,7 +42,7 @@ fn get_cli_binary_name() -> String {
         let mut hasher = Sha256::new();
         hasher.update(get_ecapture_bytes());
         let hash_string = hex::encode(hasher.finalize());
-        return format!("linux_ecapture_x86_64_{}", hash_string);
+        return format!("linux_ecapture_amd64_{}", hash_string);
     }
 
     // Linux arm64
@@ -58,7 +60,7 @@ fn get_ecapture_bytes() -> &'static [u8] {
     // Android x86_64
     #[cfg(all(target_os = "android", target_arch = "x86_64"))]
     {
-        return include_bytes!("../../binaries/android_ecapture_x86_64");
+        return include_bytes!("../../binaries/android_ecapture_amd64");
     }
 
     // Android arm64
@@ -70,7 +72,7 @@ fn get_ecapture_bytes() -> &'static [u8] {
     // Linux x86_64
     #[cfg(all(target_os = "linux", target_arch = "x86_64", not(decoupled)))]
     {
-        return include_bytes!("../../binaries/linux_ecapture_x86_64");
+        return include_bytes!("../../binaries/linux_ecapture_amd64");
     }
 
     // Linux arm64
@@ -99,9 +101,8 @@ impl CaptureManager {
     }
 
     #[cfg(target_os = "android")]
-    fn prepare_binary(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn prepare_binary(&self) -> Result<()> {
         if self.executable_path.exists() {
-            // fs::remove_file(&self.executable_path)?;
             info!("Found existing binary file");
             return Ok(());
         }
@@ -148,69 +149,80 @@ impl CaptureManager {
     pub async fn run(
         &mut self,
         mut shutdown_rx: watch::Receiver<()>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+        ecapture_args: String,
+    ) -> Result<()> {
+        // --- 1. Initial Cleanup ---
+        // Clean up any orphaned processes from previous runs.
+        let cleaner = AndroidCleaner::new();
+        let cleanup_targets = ["android_ecapture"];
+        let cleanup_exempt_names = ["com.gojue.ecaptureq"];
+        let mut exempt_pids = HashSet::new();
+        exempt_pids.insert(process::id()); // Always exempt the main app process itself.
+
+        info!("Running initial cleanup before starting process...");
+        if let Err(e) = cleaner
+            .cleanup_processes(&cleanup_targets, &exempt_pids, &cleanup_exempt_names)
+            .await
+        {
+            error!("Initial cleanup failed, continuing anyway: {}", e);
+        }
+
         self.prepare_binary()?;
 
         let binary_command = self.executable_path.to_string_lossy().to_string();
-        let full_command = format!(
-            "{} tls --ecaptureq ws://192.168.71.123:28257",
-            binary_command
-        );
-        let mut child = Command::new("su") // 使用 tokio::process::Command
+        let args_vec: Vec<&str> = ecapture_args.split_whitespace().collect();
+        let mut child = Command::new("su")
             .arg("-c")
-            .arg(&full_command)
-            .stdout(Stdio::null()) // 重定向输出
+            .arg(&binary_command)
+            .args(&args_vec)
+            .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()?;
 
-        info!("eCapture process spawned with PID: {:?}", child.id());
-        self.child = Some(child); // 将 child 存入 struct
+        info!("eCapture process started via 'su -c'.");
+        self.child = Some(child);
 
+        // --- Main event loop ---
         tokio::select! {
-            biased;
+        biased;
 
-            _ = shutdown_rx.changed() => {
+        // Branch for graceful shutdown
+        _ = shutdown_rx.changed() => {
+            info!("Shutdown signal received, cleaning up eCapture process(es)...");
 
-                if let Some(child) = self.child.as_mut() {
-                    let pid = child.id().ok_or("Failed to get child PID")?;
-
-                    // 在 Android 上, 使用 `su -c kill`
-                    info!("Running on Android, using 'su -c kill'...");
-                    let kill_command = "pkill android_test";
-                    let status = Command::new("su")
-                        .arg("-c")
-                        .arg(&kill_command)
-                        .status()
-                        .await?;
-
-                    if status.success() {
-                        info!("'su -c kill {}' command sent successfully.", pid);
-                    } else {
-                        error!("'su -c kill {}' command failed with status: {}", pid, status);
-                    }
-
-
-                    tokio::select! {
-                        result = child.wait() => {
-                            info!("eCapture process exited gracefully with result: {:?}", result);
-                        }
-                        _ = tokio::time::sleep(Duration::from_secs(3)) => {
-                            error!("Process did not exit gracefully after 5s. Forcing kill...");
-                            self.child.as_mut().unwrap().kill().await?;
-                        }
-                    }
-                }
+            if let Err(e) = cleaner
+                .cleanup_processes(&cleanup_targets, &exempt_pids, &cleanup_exempt_names)
+                .await
+            {
+                error!("Cleanup on shutdown signal failed: {}", e);
+            } else {
+                info!("Cleanup on shutdown signal completed.");
             }
 
-            result = self.child.as_mut().unwrap().wait() => {
-                match result {
-                    Ok(status) => error!("eCapture process exited unexpectedly with status: {}", status),
-                    Err(e) => error!("Error waiting for eCapture process: {}", e),
-                }
-            }
+            // The process should be terminated by the cleaner, so we can now drop the child handle.
+            self.child.take();
         }
 
-        // self.cleanup()?;
+        // Branch for unexpected process exit
+        result = self.child.as_mut().unwrap().wait() => {
+            match result {
+                Ok(status) => error!("eCapture process exited unexpectedly with status: {}", status),
+                Err(e) => error!("Error waiting for eCapture process: {}", e),
+            }
+            return Err(anyhow!("eCapture process exited unexpectedly"));
+        }
+    }
+
+        // This part is reached after a graceful shutdown.
+        // It is slightly redundant but acts as a final safety net to ensure a clean state.
+        info!("Running final cleanup before exiting...");
+        if let Err(e) = cleaner
+            .cleanup_processes(&cleanup_targets, &exempt_pids, &cleanup_exempt_names)
+            .await
+        {
+            error!("Final cleanup failed: {}", e);
+        }
+
         Ok(())
     }
 
@@ -281,6 +293,130 @@ impl Drop for CaptureManager {
                 info!("killed ecapture in drop trait")
             }
             info!("ecapture was killed, nothing to do")
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+pub struct AndroidCleaner;
+
+#[cfg(target_os = "android")]
+impl AndroidCleaner {
+    /// Creates a new cleaner instance.
+    pub fn new() -> Self {
+        AndroidCleaner
+    }
+
+    pub async fn cleanup_processes(
+        &self,
+        targets: &[&str],
+        exempt_pids: &HashSet<u32>,
+        exempt_names: &[&str],
+    ) -> Result<()> {
+        info!("Starting Android process cleanup for targets: {:?}", targets);
+
+        let find_futures = targets
+            .iter()
+            .map(|name| self.find_pids_by_name(name, exempt_names));
+        let find_results = future::join_all(find_futures).await;
+
+        let mut pids_to_kill = HashSet::new();
+        for result in find_results {
+            match result {
+                Ok(pids) => {
+                    for pid in pids {
+                        if !exempt_pids.contains(&pid) {
+                            pids_to_kill.insert(pid);
+                        }
+                    }
+                }
+                Err(e) => error!("Error finding processes during cleanup: {}", e),
+            }
+        }
+
+        if pids_to_kill.is_empty() {
+            info!("No orphaned processes found to clean up.");
+            return Ok(());
+        }
+
+        info!("Found processes to kill: {:?}", pids_to_kill);
+
+        let kill_futures = pids_to_kill.iter().map(|&pid| self.kill_process(pid));
+        let kill_results = future::join_all(kill_futures).await;
+
+        let killed_count = kill_results.into_iter().filter(|res| res.is_ok()).count();
+        info!(
+            "Cleanup finished. Attempted to kill {} processes, {} succeeded.",
+            pids_to_kill.len(),
+            killed_count
+        );
+
+        Ok(())
+    }
+
+    /// Finds PIDs by searching the full command line arguments.
+    async fn find_pids_by_name(
+        &self,
+        keyword: &str,
+        exempt_names: &[&str],
+    ) -> Result<Vec<u32>> {
+        let ps_command = "ps -A -o PID,ARGS";
+
+        // Execute the `ps` command as root to see all processes.
+        let output = Command::new("su")
+            .arg("-c")
+            .arg(ps_command)
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            error!("Root `ps` command failed with status: {}. Stderr: {}", output.status, stderr);
+            return Err(anyhow!("Failed to execute 'ps' as root"));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut pids = Vec::new();
+
+        for line in stdout.lines().skip(1) { // Skip header
+            let trimmed_line = line.trim();
+            // Split into PID and the rest of the line (ARGS)
+            let parts: Vec<&str> = trimmed_line.splitn(2, char::is_whitespace).collect();
+
+            if parts.len() == 2 {
+                let pid_str = parts[0];
+                let full_args = parts[1];
+
+                let is_self_ps_command = full_args.contains(ps_command);
+
+                if full_args.contains(keyword) && !is_self_ps_command {
+                    let is_exempted_by_name = exempt_names.iter().any(|&name| full_args.contains(name));
+
+                    if !is_exempted_by_name {
+                        if let Ok(pid) = pid_str.parse::<u32>() {
+                            pids.push(pid);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(pids)
+    }
+
+    /// Kills the specified process by PID using `su`.
+    async fn kill_process(&self, pid: u32) -> Result<()> {
+        let status = Command::new("su")
+            .arg("-c")
+            .arg(format!("kill -9 {}", pid))
+            .status()
+            .await?;
+
+        if status.success() {
+            info!("Successfully terminated process with PID: {}", pid);
+            Ok(())
+        } else {
+            error!("Failed to kill process with PID: {}. It might have already exited.", pid);
+            Err(anyhow!("Failed to kill PID: {}", pid))
         }
     }
 }

--- a/src-tauri/src/tauri_bridge/commands.rs
+++ b/src-tauri/src/tauri_bridge/commands.rs
@@ -7,7 +7,6 @@ use tauri::Manager;
 use tokio::time::{Duration, sleep};
 use wg::AsyncWaitGroup;
 
-
 #[cfg(all(not(decoupled), any(target_os = "linux", target_os = "android")))]
 use crate::services::capture::CaptureManager;
 use crate::services::{push_service::PushService, websocket::WebsocketService};
@@ -64,16 +63,10 @@ pub async fn start_capture(
         let capture_wg_clone = capture_wg.clone();
         // spawn ecapture service
         tokio::spawn(async move {
-            #[cfg(target_os = "linux")]
             let result = capture_manager
                 .run(rx, configs.ecapture_args.unwrap_or_default())
                 .await;
-            
-            #[cfg(target_os = "android")]
-            let result = capture_manager
-                .run(rx)
-                .await;
-            
+
             if let Err(e) = result {
                 error!("[CaptureManager] Task failed: {}", e);
                 capture_error_inspector.store(true, Ordering::Release);


### PR DESCRIPTION
- Introduced a new `AndroidCleaner` service to reliably find and terminate leftover capture processes from previous sessions.
- The cleaner runs automatically before a new capture starts and during shutdown, ensuring a clean state.
- This significantly improves the stability and reliability of starting and stopping captures, especially after an application crash.
- Refactored `CaptureManager` to use the new cleaner service for a unified shutdown procedure.