### PR TITLE
feat: Update CI workflows for eCapture; generalize artifact naming and add new release workflow

### DIFF
--- a/.github/workflows/pr_build_android.yml
+++ b/.github/workflows/pr_build_android.yml
@@ -161,34 +161,14 @@ jobs:
             const runId = context.runId;
             const prNumber = context.payload.pull_request.number;
             
-            let comment = `## 🔨 PR Build Results (Android)\n\n`;
-            if (artifacts.artifacts.length > 0) {
-              comment += `✅ Build completed successfully!\n\n`;
-              comment += `### 📦 Download Artifacts:\n`;
-            
-              for (const artifact of artifacts.artifacts) {
-                let arch = 'Unknown';
-                if (artifact.name.includes('aarch64') || artifact.name.includes('arm64')) {
-                  arch = 'aarch64 (ARM64)';
-              } else if (artifact.name.includes('x86_64')|| artifact.name.includes('amd64')) {
-                  arch = 'x86_64';
-              }
-              comment += `- 📱 Android [${arch}]: [${artifact.name}](${artifact.archive_download_url})\n`;
-              }
-            
-              comment += `\n💡 **How to test:**\n`;
-              comment += `1. Download the artifact for your platform\n`;
-              comment += `2. Extract the archive\n`;
-              comment += `3. Install/run the application\n`;
-              comment += `4. Report any issues in this PR\n\n`;
-              comment += `⏰ Artifacts will be available for 7 days.\n`;
-            } else {
-              comment += `❌ Build failed. Please check the workflow logs for details.\n`;
-            }
-            
             github.rest.issues.createComment({
               issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: comment,
+              body: `🔧 **Debug Build Complete (Android)**
+
+              📦 Download Links:
+              - [PR ${prNumber} Debug Binary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})
+
+              ⏰ Files will be retained for 7 days, please download and test promptly.`
             });

--- a/.github/workflows/pr_build_android.yml
+++ b/.github/workflows/pr_build_android.yml
@@ -91,16 +91,6 @@ jobs:
       - name: Install NDK
         run: sdkmanager "ndk;26.1.10909125"
 
-      - name: Debug OpenSSL
-        run: |
-          echo "OpenSSL version:"
-          openssl version
-          echo "PKG_CONFIG_PATH:"
-          echo $PKG_CONFIG_PATH
-          echo "OpenSSL pkg-config:"
-          pkg-config --modversion openssl || echo "OpenSSL pkg-config not found"
-          echo "System libraries:"
-          ldconfig -p | grep ssl
       # --- 关键步骤：创建 keystore.properties 文件 ---
       - name: Create keystore.properties for Android signing
         run: |

--- a/.github/workflows/pr_build_android.yml
+++ b/.github/workflows/pr_build_android.yml
@@ -142,19 +142,13 @@ jobs:
           pnpm tauri android init
           pnpm tauri android build --target ${{ matrix.arch }}
 
-      - name: Sign APK
-        run: |
-          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks src-tauri/gen/android/release.decrypted.jks \
-          src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: eCaptureQ-pr${{ github.event.number }}-${{ github.sha }}-${{ matrix.arch }}.apk
-          if-no-files-found: ignore
-          path: |
-            src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk
+          name: eCaptureQ-pr${{ github.event.number }}-${{ github.run_id }}-${{ matrix.arch }}.apk
           retention-days: 7
+          path: |
+            src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
 
   comment-pr:
     needs: build-android

--- a/.github/workflows/pr_build_android.yml
+++ b/.github/workflows/pr_build_android.yml
@@ -48,14 +48,12 @@ jobs:
           
           ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-android-${ECAPTURE_ARCH}.tar.gz"
           ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-android-${ECAPTURE_ARCH}"
-          
+
           wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
           tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
-          
-          ls -al
+
           mkdir -p src-tauri/binaries
-          cp "${ECAPTURE_DIR}/ecapture" src-tauri/binaries/android_test-aarch64-linux-android || { echo "Copy failed"; exit 1; }
-          cp "${ECAPTURE_DIR}/ecapture" src-tauri/binaries/linux_ecapture_test || { echo "Copy failed"; exit 1; }
+          cp "${ECAPTURE_DIR}/ecapture" src-tauri/binaries/android_ecapture_${ECAPTURE_ARCH} || { echo "Copy failed"; exit 1; }
           ls src-tauri/binaries/
 
       - name: Rust setup
@@ -139,12 +137,6 @@ jobs:
       - name: Build and Sign Android App for ${{ matrix.arch }}
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
-#          OPENSSL_DIR: /usr
-#          OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu
-#          OPENSSL_INCLUDE_DIR: /usr/include/openssl
-#          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig
-#          OPENSSL_STATIC: "0"
-#          RUST_BACKTRACE: 1
         run: |
           rm -rf src-tauri/gen/android
           pnpm tauri android init

--- a/.github/workflows/pr_build_android.yml
+++ b/.github/workflows/pr_build_android.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '23'
+          java-version: '17'
 
       # 下载并配置 Android SDK/NDK
       - name: Setup Android SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,7 @@ jobs:
         run: |
           # 动态创建 src-tauri/gen/android 目录（如果不存在）
           pwd
+          pnpm tauri android init
           mkdir -p src-tauri/gen/android
 
           # 将 Base64 编码的密钥文件解码，并保存到 Runner 的临时目录
@@ -202,6 +203,7 @@ jobs:
           EOF
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
 
 
       - name: eCaptureQ build (non-Android)
@@ -234,7 +236,6 @@ jobs:
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: |
-          pnpm tauri android init
           pnpm tauri android build --target ${{ matrix.arch }}
 
       - name: Rename APK file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,10 +233,8 @@ jobs:
       - name: Pnpm install
         run: pnpm i
 
-      # --- 修正后的核心步骤: 设置交叉编译环境 ---
       - name: Setup cross-compilation environment for Linux ARM
         run: |
-          # 1. 创建全新的、格式正确的 sources.list 文件
           cat > /tmp/sources.list << EOF
           deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
           deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
@@ -247,12 +245,8 @@ jobs:
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
           EOF
-          
-          # 2. 备份旧文件并替换为新文件
           sudo mv /etc/apt/sources.list /etc/apt/sources.list.bak
           sudo mv /tmp/sources.list /etc/apt/sources.list
-          
-          # 3. 添加 ARM 架构支持并更新
           sudo dpkg --add-architecture arm64
           sudo apt-get update
 
@@ -288,6 +282,7 @@ jobs:
 
       - name: Build Linux ARM Artifact
         env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
           PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
           PKG_CONFIG_ALLOW_CROSS: 1
         run: pnpm tauri build --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,9 @@ jobs:
           fi
           echo "Tag and package.json version are consistent."
 
+  # Job 1: 构建 Windows, macOS, Linux x86_64 和 Android
   build-artifacts:
-    name: Build and Release
+    name: Build Main Artifacts
     needs: [get_version]
     strategy:
       fail-fast: false
@@ -68,10 +69,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             arch: x86_64
           - os: ubuntu-22.04
-            platform: linux
-            target: aarch64-unknown-linux-gnu
-            arch: aarch64
-          - os: ubuntu-22.04
             platform: android
             target: x86_64-linux-android
             arch: x86_64
@@ -87,21 +84,16 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable
 
+      # ... Android 相关步骤保持不变 ...
       - name: Set up Java
         if: matrix.platform == 'android'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-
       - name: Setup Android SDK
         if: matrix.platform == 'android'
         uses: android-actions/setup-android@v3
-        with:
-          api-level: 34
-          build-tools: 34.0.0
-          ndk-version: 26.1.10909125
-
       - name: Install NDK
         if: matrix.platform == 'android'
         run: sdkmanager "ndk;26.1.10909125"
@@ -112,8 +104,9 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install dependencies (ubuntu only)
-        if: matrix.os == 'ubuntu-22.04'
+      # 这个步骤现在只为 x86_64 Linux 安装原生依赖
+      - name: Install dependencies (ubuntu x86_64 only)
+        if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev libgtk-3-dev libssl-dev xdg-utils librsvg2-dev libappindicator3-dev patchelf
@@ -122,25 +115,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: latest
-
       - name: Pnpm install
         run: pnpm i
 
+      # ... Android 初始化步骤保持不变 ...
       - name: Initialize Tauri Android Project
         if: matrix.platform == 'android'
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: pnpm tauri android init
 
-      - name: Download and Setup eCapture (for Linux/Android build)
+      - name: Download and Setup eCapture
         shell: bash
         if: matrix.platform == 'linux' || matrix.platform == 'android'
         run: |
+          # 这部分逻辑现在对于这个 Job 来说总是正确的
           echo ">>> Setting up eCapture for ${{ matrix.platform }}-${{ matrix.arch }}..."
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
             ECAPTURE_ARCH="amd64"
@@ -150,32 +143,26 @@ jobs:
           ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
           if [[ -z "$ECAPTURE_LATEST" ]]; then echo "Failed to fetch eCapture version."; exit 1; fi
           ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}.tar.gz"
-          echo "Downloading ${ECAPTURE_TAR}..."
-          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
-          echo "Extracting archive..."
-          tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
+          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}"
+          tar -zxvf "${ECAPTURE_TAR}"
           SOURCE_FILE=$(find . -name ecapture -type f | head -n 1)
-          if [[ -z "$SOURCE_FILE" ]]; then echo "ERROR: Could not find 'ecapture' executable!"; ls -R; exit 1; fi
-          echo "Found ecapture executable at: ${SOURCE_FILE}"
           mkdir -p src-tauri/binaries
           DEST_FILE="src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
-          echo "Copying ${SOURCE_FILE} to ${DEST_FILE}"
-          cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
-          echo ">>> Verification Step: Listing contents of src-tauri/binaries/ directory..."
+          cp "${SOURCE_FILE}" "${DEST_FILE}"
           ls -l src-tauri/binaries/
-          echo ">>> Setup complete."
 
+      # --- 修改点: 为所有桌面构建添加 --target 参数 ---
       - name: Build Desktop Artifacts (Windows/macOS/Linux)
         if: matrix.platform != 'android'
-        run: pnpm tauri build
+        run: pnpm tauri build --target ${{ matrix.target }}
 
+      # ... Android 构建和发布步骤保持不变 ...
       - name: Build Android Artifact
         if: matrix.platform == 'android'
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: |
           pnpm tauri android build --target ${{ matrix.arch }}
-
       - name: Sign Android APK
         if: matrix.platform == 'android'
         id: sign_apk
@@ -188,27 +175,10 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
           BUILD_TOOLS_VERSION: "34.0.0"
-
       - name: Rename Signed Artifact
         if: matrix.platform == 'android'
         run: |
-          echo "Signed APK path is: ${{ steps.sign_apk.outputs.signedReleaseFile }}"
           mv "${{ steps.sign_apk.outputs.signedReleaseFile }}" "./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk"
-
-      - name: Publish Desktop Artifacts
-        if: matrix.platform != 'android'
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          name: eCaptureQ v${{ needs.get_version.outputs.version }}
-          tag_name: v${{ needs.get_version.outputs.version }}
-          generate_release_notes: true
-          files: |
-            src-tauri/target/release/bundle/msi/eCaptureQ_*.msi
-            src-tauri/target/release/bundle/nsis/eCaptureQ_*-setup.exe
-            src-tauri/target/release/bundle/dmg/eCaptureQ_*.dmg
-            src-tauri/target/release/bundle/appimage/eCaptureQ_*.AppImage
-
       - name: Publish Android Artifact
         if: matrix.platform == 'android'
         uses: softprops/action-gh-release@v1
@@ -218,3 +188,123 @@ jobs:
           tag_name: v${{ needs.get_version.outputs.version }}
           generate_release_notes: true
           files: ./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk
+
+      # --- 修改点: 确保文件路径正确匹配 target ---
+      - name: Publish Desktop Artifacts
+        if: matrix.platform != 'android'
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          name: eCaptureQ v${{ needs.get_version.outputs.version }}
+          tag_name: v${{ needs.get_version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/msi/eCaptureQ_*.msi
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/eCaptureQ_*-setup.exe
+            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/eCaptureQ_*.dmg
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/eCaptureQ_*.AppImage
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+
+  # --- 新增 Job: 专门用于交叉编译 Linux ARM ---
+  build-linux-arm:
+    name: Build and Release for Linux ARM
+    needs: [get_version]
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust Target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: latest
+      - name: Pnpm install
+        run: pnpm i
+
+      # --- 核心步骤: 设置交叉编译环境 ---
+      - name: Setup cross-compilation environment for Linux ARM
+        run: |
+          # 1. 添加 ARM 架构支持
+          sudo dpkg --add-architecture arm64
+          # 2. 修改 apt 源，使其能找到 ARM 架构的包
+          # 使用 sed 在现有源的每一行末尾添加 [arch=amd64] 
+          sudo sed -i -e 's/$/ \[arch=amd64\]/' /etc/apt/sources.list
+          # 添加 ARM 的源
+          cat <<EOF | sudo tee -a /etc/apt/sources.list
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
+          EOF
+          sudo apt-get update
+
+      # --- 核心步骤: 安装 aarch64 版本的依赖库 ---
+      - name: Install ARM dependencies
+        run: |
+          sudo apt-get install -y \
+            libsoup-3.0-dev:arm64 \
+            libjavascriptcoregtk-4.1-dev:arm64 \
+            libwebkit2gtk-4.1-dev:arm64 \
+            libgtk-3-dev:arm64 \
+            libssl-dev:arm64 \
+            xdg-utils:arm64 \
+            librsvg2-dev:arm64 \
+            libappindicator3-dev:arm64 \
+            patchelf:arm64
+
+      # --- 核心步骤: 安装 C 语言的交叉编译器 ---
+      - name: Install C cross-compiler for aarch64
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Download and Setup eCapture for Linux ARM
+        shell: bash
+        run: |
+          echo ">>> Setting up eCapture for linux-arm64..."
+          ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
+          ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-linux-arm64.tar.gz"
+          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}"
+          tar -zxvf "${ECAPTURE_TAR}"
+          SOURCE_FILE=$(find . -name ecapture -type f | head -n 1)
+          mkdir -p src-tauri/binaries
+          DEST_FILE="src-tauri/binaries/linux_ecapture_arm64"
+          cp "${SOURCE_FILE}" "${DEST_FILE}"
+          ls -l src-tauri/binaries/
+
+      # --- 核心步骤: 执行交叉编译，并设置所需的环境变量 ---
+      - name: Build Linux ARM Artifact
+        env:
+          # 设置 pkg-config 环境变量，让构建系统能找到 aarch64 的库
+          PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
+          PKG_CONFIG_ALLOW_CROSS: 1
+        run: pnpm tauri build --target ${{ matrix.target }}
+
+      # --- 新增步骤: 为这个 Job 单独发布产物 ---
+      - name: Publish Linux ARM Artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          name: eCaptureQ v${{ needs.get_version.outputs.version }}
+          tag_name: v${{ needs.get_version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/eCaptureQ_*.AppImage
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,14 +185,14 @@ jobs:
           mkdir -p src-tauri/gen/android
 
           # 将 Base64 编码的密钥文件解码，并保存到 Runner 的临时目录
-          echo "${{ secrets.ANDROID_SIGNING_DEBUG_KEY }}" | base64 --decode > src-tauri/gen/android/release.decrypted.jks
+          echo "${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}" | base64 --decode > src-tauri/gen/android/release.decrypted.jks
 
           # 将签名信息写入 keystore.properties 文件
           cat <<EOF > src-tauri/gen/android/keystore.properties
-          password=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_PASSWORD }}
-          keyAlias=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_ALIAS }}
+          password=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS }}
           storeFile=${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks
-          keyPassword=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_ALIAS_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
           EOF
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,25 +131,9 @@ jobs:
       - name: Pnpm install
         run: pnpm i
 
-      - name: Create keystore.properties for Android signing
-        if: matrix.platform == 'android'
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
-        run: |
-          pnpm tauri android init
-          echo "${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}" | base64 --decode > release.decrypted.jks
-          mkdir -p src-tauri/gen/android
-          cat <<EOF > src-tauri/gen/android/keystore.properties
-          password=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
-          keyAlias=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS }}
-          storeFile=${{ github.workspace }}/release.decrypted.jks
-          keyPassword=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
-          EOF
-
       - name: Download and Setup eCapture (Just Before Build)
         shell: bash
-        if: matrix.platform == 'linux' || matrix.platform == 'android'
+        if: matrix.platform == 'linux'
         run: |
           echo ">>> Setting up eCapture for ${{ matrix.platform }}-${{ matrix.arch }}..."
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
@@ -181,14 +165,12 @@ jobs:
           fi
           echo "Found ecapture executable at: ${SOURCE_FILE}"
 
-          # Corrected path: Place binaries inside src-tauri/
           mkdir -p src-tauri/binaries
           DEST_FILE="src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
           
           echo "Copying ${SOURCE_FILE} to ${DEST_FILE}"
           cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
           
-          # Corrected path: Verify the file in its new location
           echo ">>> Verification Step: Listing contents of src-tauri/binaries/ directory..."
           ls -l src-tauri/binaries/
           echo ">>> Setup complete. Proceeding to build."
@@ -204,10 +186,24 @@ jobs:
         run: |
           pnpm tauri android build --target ${{ matrix.arch }}
 
-      - name: Rename Android Artifact
+      - name: Sign Android APK
+        if: matrix.platform == 'android'
+        id: sign_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: src-tauri/gen/android/app/build/outputs/apk/universal/release
+          signingKeyBase64: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}
+          alias: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
+
+      - name: Rename Signed Artifact
         if: matrix.platform == 'android'
         run: |
-          mv src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk ./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk
+          echo "Signed APK path is: ${{ steps.sign_apk.outputs.signedReleaseFile }}"
+          mv "${{ steps.sign_apk.outputs.signedReleaseFile }}" "./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk"
 
       - name: Publish Desktop Artifacts
         if: matrix.platform != 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
         if: matrix.platform != 'android'
         uses: tauri-apps/tauri-action@v0
         env:
+          DECOUPLED_MODE: true
           NODE_OPTIONS: "--max_old_space_size=4096"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           echo "package.json version: $PKG_VERSION"
           if [[ "$TAG_REF" != "v$PKG_VERSION" ]]; then
             echo "Tag ($TAG_REF) does not match package.json version (v$PKG_VERSION)."
-            exit 1
+            exit 0
           fi
           echo "Tag and package.json version are consistent."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,9 +131,14 @@ jobs:
       - name: Pnpm install
         run: pnpm i
 
-      - name: Download and Setup eCapture (Just Before Build)
+      - name: Initialize Tauri Android Project
+        if: matrix.platform == 'android'
+        run: pnpm tauri android init
+
+      - name: Download and Setup eCapture (for Linux/Android build)
         shell: bash
-        if: matrix.platform == 'linux'
+        # 因为你的 Rust 代码在编译 Android 时也需要 include_bytes!，所以这里也需要下载
+        if: matrix.platform == 'linux' || matrix.platform == 'android'
         run: |
           echo ">>> Setting up eCapture for ${{ matrix.platform }}-${{ matrix.arch }}..."
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
@@ -141,39 +146,23 @@ jobs:
           else
             ECAPTURE_ARCH="arm64"
           fi
-          
           ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
-          if [[ -z "$ECAPTURE_LATEST" ]]; then
-            echo "Failed to fetch the latest eCapture release version."
-            exit 1
-          fi
-
+          if [[ -z "$ECAPTURE_LATEST" ]]; then echo "Failed to fetch eCapture version."; exit 1; fi
           ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}.tar.gz"
-          
           echo "Downloading ${ECAPTURE_TAR}..."
           wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
-          
           echo "Extracting archive..."
           tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
-          
           SOURCE_FILE=$(find . -name ecapture -type f | head -n 1)
-          if [[ -z "$SOURCE_FILE" ]]; then
-            echo "ERROR: Could not find 'ecapture' executable after extraction!"
-            echo "--- Listing all extracted files for debugging ---"
-            ls -R
-            exit 1
-          fi
+          if [[ -z "$SOURCE_FILE" ]]; then echo "ERROR: Could not find 'ecapture' executable!"; ls -R; exit 1; fi
           echo "Found ecapture executable at: ${SOURCE_FILE}"
-
           mkdir -p src-tauri/binaries
           DEST_FILE="src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
-          
           echo "Copying ${SOURCE_FILE} to ${DEST_FILE}"
           cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
-          
           echo ">>> Verification Step: Listing contents of src-tauri/binaries/ directory..."
           ls -l src-tauri/binaries/
-          echo ">>> Setup complete. Proceeding to build."
+          echo ">>> Setup complete."
 
       - name: Build Desktop Artifacts (Windows/macOS/Linux)
         if: matrix.platform != 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,7 @@ jobs:
       - name: Sign APK
         if: matrix.platform == 'android'
         run: |
+          du -sh ./src-tauri/gen/android/release.decrypted.jks
           ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
           src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,11 @@ jobs:
           # Android
           - os: ubuntu-22.04
             platform: android
-            target: x86_64
+            target: x86_64-linux-android
             arch: x86_64
           - os: ubuntu-22.04
             platform: android
-            target: aarch64
+            target: aarch64-linux-android
             arch: aarch64
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,40 +118,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev libgtk-3-dev libssl-dev xdg-utils librsvg2-dev libappindicator3-dev patchelf
 
-      - name: Download and setup eCapture
-        shell: bash
-        if: matrix.platform == 'linux' || matrix.platform == 'android'
-        run: |
-          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
-            ECAPTURE_ARCH="amd64"
-          else
-            ECAPTURE_ARCH="arm64"
-          fi
-          
-          ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
-          if [[ -z "$ECAPTURE_LATEST" ]]; then
-            echo "Failed to fetch the latest eCapture release version."
-            exit 1
-          fi
-
-          # This logic now correctly uses the platform name from the matrix
-          ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}.tar.gz"
-          ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}"
-
-          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download for ${{ matrix.platform }} failed"; exit 1; }
-          tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
-          
-          # Place the binary in the root `binaries/` directory as required by the Rust code
-          mkdir -p binaries
-          
-          SOURCE_FILE="${ECAPTURE_DIR}/ecapture"
-          DEST_FILE="binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
-          
-          cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
-          
-          echo "Contents of binaries directory:"
-          ls -l binaries/
-
       - name: Install Node
         uses: actions/setup-node@v4
         with:
@@ -180,6 +146,52 @@ jobs:
           storeFile=${{ github.workspace }}/release.decrypted.jks
           keyPassword=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
           EOF
+
+      - name: Download and Setup eCapture (Just Before Build)
+        shell: bash
+        if: matrix.platform == 'linux' || matrix.platform == 'android'
+        run: |
+          echo ">>> Setting up eCapture for ${{ matrix.platform }}-${{ matrix.arch }}..."
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            ECAPTURE_ARCH="amd64"
+          else
+            ECAPTURE_ARCH="arm64"
+          fi
+          
+          ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
+          if [[ -z "$ECAPTURE_LATEST" ]]; then
+            echo "Failed to fetch the latest eCapture release version."
+            exit 1
+          fi
+
+          ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}.tar.gz"
+          
+          echo "Downloading ${ECAPTURE_TAR}..."
+          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
+          
+          echo "Extracting archive..."
+          tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
+          
+          SOURCE_FILE=$(find . -name ecapture -type f | head -n 1)
+          if [[ -z "$SOURCE_FILE" ]]; then
+            echo "ERROR: Could not find 'ecapture' executable after extraction!"
+            echo "--- Listing all extracted files for debugging ---"
+            ls -R
+            exit 1
+          fi
+          echo "Found ecapture executable at: ${SOURCE_FILE}"
+
+          # Corrected path: Place binaries inside src-tauri/
+          mkdir -p src-tauri/binaries
+          DEST_FILE="src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
+          
+          echo "Copying ${SOURCE_FILE} to ${DEST_FILE}"
+          cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
+          
+          # Corrected path: Verify the file in its new location
+          echo ">>> Verification Step: Listing contents of src-tauri/binaries/ directory..."
+          ls -l src-tauri/binaries/
+          echo ">>> Setup complete. Proceeding to build."
 
       - name: Build Desktop Artifacts (Windows/macOS/Linux)
         if: matrix.platform != 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           echo "Current tag: $TAG_REF"
           PKG_VERSION=$(jq -r .version package.json)
           echo "package.json version: $PKG_VERSION"
+          echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
           if [[ "$TAG_REF" != "v$PKG_VERSION" ]]; then
             echo "Tag ($TAG_REF) does not match package.json version (v$PKG_VERSION)."
             exit 0
@@ -223,10 +224,10 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: v${{ github.ref }}
+          tagName: v${{ steps.get_version.outputs.version }}
           appName: eCaptureQ
-          appVersion: ${{ github.ref }}
-          releaseName: "eCaptureQ v${{ github.ref }}"
+          appVersion: ${{ steps.get_version.outputs.version }}
+          releaseName: "eCaptureQ v${{ steps.get_version.outputs.version }}"
           releaseBody: ""
           releaseDraft: true
           prerelease: 'false'
@@ -241,21 +242,21 @@ jobs:
       - name: Rename APK file
         if: matrix.platform == 'android'
         run: |
-          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ github.ref }}_${{ matrix.arch }}.apk
+          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
 
       - name: Sign APK
         if: matrix.platform == 'android'
         run: |
           ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
-          src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ github.ref }}_${{ matrix.arch }}.apk
+          src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
 
       - name: Publish
         if: matrix.platform == 'android'
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          name: eCaptureQ v${{ github.ref }}
-          tag_name: v${{ github.ref }}
+          name: eCaptureQ v${{ steps.get_version.outputs.version }}
+          tag_name: v${{ steps.get_version.outputs.version }}
           generate_release_notes: true
           files: |
-            ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaptureQ_v${{ github.ref }}_${{ matrix.arch }}.apk
+            ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaptureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           DECOUPLED_MODE: true
+          RUST_TARGET: ${{ matrix.target }}
           NODE_OPTIONS: "--max_old_space_size=4096"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}
@@ -221,8 +222,8 @@ jobs:
           tagName: v__VERSION__
           releaseName: "eCaptureQ v__VERSION__"
           releaseBody: "More new features are now supported."
+          appVersion: v__VERSION__
           tauriScript: pnpm
-          args: --target ${{ matrix.target }}
 
       - name: eCaptureQ build (Android) ${{ matrix.arch }}
         if: matrix.platform == 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '23'
+          java-version: '17'
 
       # 下载并配置 Android SDK/NDK
       - name: Setup Android SDK
@@ -178,10 +178,17 @@ jobs:
         with:
           version: latest
 
+      # 安装前端依赖
+      - name: Pnpm install
+        run: |
+          pnpm i
+
       - name: Create keystore.properties for Android signing
         if: matrix.platform == 'android'
         run: |
           # 动态创建 src-tauri/gen/android 目录（如果不存在）
+          pwd
+          pnpm tauri android init
           mkdir -p src-tauri/gen/android
 
           # 将 Base64 编码的密钥文件解码，并保存到 Runner 的临时目录
@@ -197,10 +204,6 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
-      # 安装前端依赖
-      - name: Pnpm install
-        run: |
-          pnpm i
 
       - name: eCaptureQ build (non-Android)
         if: matrix.platform != 'android'
@@ -219,10 +222,10 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: v${{ steps.get_version.outputs.version }}
+          tagName: v${{ github.ref }}
           appName: eCaptureQ
-          appVersion: ${{ steps.get_version.outputs.version }}
-          releaseName: "eCaptureQ v${{ steps.get_version.outputs.version }}"
+          appVersion: ${{ github.ref }}
+          releaseName: "eCaptureQ v${{ github.ref }}"
           releaseBody: "More new features are now supported."
 
       - name: eCaptureQ build (Android) ${{ matrix.arch }}
@@ -230,8 +233,6 @@ jobs:
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: |
-          rm -rf src-tauri/gen/android
-          pnpm tauri android init
           pnpm tauri android build --target ${{ matrix.arch }}
 
       - name: Sign APK
@@ -244,15 +245,15 @@ jobs:
       - name: Rename APK file
         if: matrix.platform == 'android'
         run: |
-          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
+          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ github.ref }}_${{ matrix.arch }}.apk
 
       - name: Publish
         if: matrix.platform == 'android'
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          name: eCaptureQ v${{ steps.get_version.outputs.version }}
-          tag_name: v${{ steps.get_version.outputs.version }}
+          name: eCaptureQ v${{ github.ref }}
+          tag_name: v${{ github.ref }}
           generate_release_notes: true
           files: |
-            ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaptureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
+            ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaptureQ_v${{ github.ref }}_${{ matrix.arch }}.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,42 @@ jobs:
           fi
           echo "Tag and package.json version are consistent."
 
+  generate-changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    needs: check_tag_version
+    outputs:
+      changelog: ${{ steps.changelog.outputs.log }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 获取所有历史记录以访问所有 tags
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          # 获取最新的两个 tag
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          PREVIOUS_TAG=$(git describe --tags `git rev-list --tags --skip=1 --max-count=1`)
+          
+          echo "Latest Tag: $LATEST_TAG"
+          echo "Previous Tag: $PREVIOUS_TAG"
+          
+          # 生成这两个 tag 之间的 commit log
+          LOG_CONTENT=$(git log ${PREVIOUS_TAG}..${LATEST_TAG} --pretty=format:"* %s (%h)")
+          
+          # 处理多行字符串以便输出
+          LOG_CONTENT="${LOG_CONTENT//'%'/'%25'}"
+          LOG_CONTENT="${LOG_CONTENT//$'\n'/'%0A'}"
+          LOG_CONTENT="${LOG_CONTENT//$'\r'/'%0D'}"
+          
+          echo "log=$LOG_CONTENT" >> $GITHUB_OUTPUT
+
   # 任务 2: 为 Windows, macOS, Linux, 和 Android 构建和发布
   build-artifacts:
     name: Build and Release
-    needs: check_tag_version
+    needs: [check_tag_version, generate-changelog]
     strategy:
       fail-fast: false
       matrix:
@@ -188,7 +220,6 @@ jobs:
         run: |
           # 动态创建 src-tauri/gen/android 目录（如果不存在）
           pwd
-          pnpm tauri android init
           mkdir -p src-tauri/gen/android
 
           # 将 Base64 编码的密钥文件解码，并保存到 Runner 的临时目录
@@ -226,26 +257,26 @@ jobs:
           appName: eCaptureQ
           appVersion: ${{ github.ref }}
           releaseName: "eCaptureQ v${{ github.ref }}"
-          releaseBody: "More new features are now supported."
+          releaseBody: "${{ needs.generate-changelog.outputs.changelog }}"
 
       - name: eCaptureQ build (Android) ${{ matrix.arch }}
         if: matrix.platform == 'android'
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: |
+          pnpm tauri android init
           pnpm tauri android build --target ${{ matrix.arch }}
-
-      - name: Sign APK
-        if: matrix.platform == 'android'
-        run: |
-          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
-          src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
-
 
       - name: Rename APK file
         if: matrix.platform == 'android'
         run: |
           mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ github.ref }}_${{ matrix.arch }}.apk
+
+      - name: Sign APK
+        if: matrix.platform == 'android'
+        run: |
+          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
+          src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ github.ref }}_${{ matrix.arch }}.apk
 
       - name: Publish
         if: matrix.platform == 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   # 任务 1: 检查 Git Tag 和 package.json 的版本是否一致
-  check_tag_version:
+  get_version:
     name: Check Release Tag and package.json Version Consistency
     runs-on: ubuntu-latest
     outputs:
@@ -55,7 +55,7 @@ jobs:
   # 任务 2: 为 Windows, macOS, Linux, 和 Android 构建和发布
   build-artifacts:
     name: Build and Release
-    needs: [check_tag_version]
+    needs: [get_version]
     strategy:
       fail-fast: false
       matrix:
@@ -239,16 +239,16 @@ jobs:
         run: |
           pnpm tauri android build --target ${{ matrix.arch }}
 
-      - name: Rename APK file
-        if: matrix.platform == 'android'
-        run: |
-          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
-
       - name: Sign APK
         if: matrix.platform == 'android'
         run: |
           ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
-          src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
+          src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
+
+      - name: Rename APK file
+        if: matrix.platform == 'android'
+        run: |
+          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
 
       - name: Publish
         if: matrix.platform == 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev libgtk-3-dev libssl-dev xdg-utils librsvg2-dev libappindicator3-dev patchelf
 
-      # [修正] 修正了 ecapture 的下载逻辑
       - name: Download and setup eCapture for ${{ matrix.arch }}
         shell: bash
         if: matrix.platform == 'linux' || matrix.platform == 'android'
@@ -129,7 +128,6 @@ jobs:
             ECAPTURE_ARCH="arm64"
           fi
           
-          # 判断平台，如果是 android，则下载 linux 版本的 ecapture
           ECAPTURE_PLATFORM="${{ matrix.platform }}"
           if [[ "${{ matrix.platform }}" == "android" ]]; then
             echo "Android platform detected. Using 'linux' binaries for eCapture."
@@ -145,21 +143,14 @@ jobs:
           ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${ECAPTURE_PLATFORM}-${ECAPTURE_ARCH}.tar.gz"
           ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-${ECAPTURE_PLATFORM}-${ECAPTURE_ARCH}"
 
-          echo "Downloading: ${ECAPTURE_TAR}"
           wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
-          
-          echo "Extracting from: ${ECAPTURE_TAR}"
           tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
-
           mkdir -p src-tauri/binaries
           
           SOURCE_FILE="${ECAPTURE_DIR}/ecapture"
           DEST_FILE="src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
           
-          echo "Copying from ${SOURCE_FILE} to ${DEST_FILE}"
           cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
-          
-          echo "Contents of binaries directory:"
           ls src-tauri/binaries/
 
       - name: Install Node
@@ -175,16 +166,14 @@ jobs:
       - name: Pnpm install
         run: pnpm i
 
-      # [修正] 为此步骤添加了 NDK_HOME 环境变量
       - name: Create keystore.properties for Android signing
         if: matrix.platform == 'android'
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
-          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125 # <-- 这里采纳了您范例中的正确设置
         run: |
           pnpm tauri android init
           echo "${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}" | base64 --decode > release.decrypted.jks
-          # 确保目录存在，增加稳健性
           mkdir -p src-tauri/gen/android
           cat <<EOF > src-tauri/gen/android/keystore.properties
           password=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
@@ -193,19 +182,11 @@ jobs:
           keyPassword=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
           EOF
 
-      - name: eCaptureQ build (non-Android)
+      - name: Build Desktop Artifacts (Windows/macOS/Linux)
         if: matrix.platform != 'android'
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: v${{ needs.get_version.outputs.version }}
-          releaseName: "eCaptureQ v${{ needs.get_version.outputs.version }}"
-          releaseBody: ""
-          releaseDraft: true
-          prerelease: false
+        run: pnpm tauri build
 
-      - name: eCaptureQ build (Android) ${{ matrix.arch }}
+      - name: Build Android Artifact
         if: matrix.platform == 'android'
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
@@ -216,6 +197,20 @@ jobs:
         if: matrix.platform == 'android'
         run: |
           mv src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk ./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk
+
+      - name: Publish Desktop Artifacts
+        if: matrix.platform != 'android'
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          name: eCaptureQ v${{ needs.get_version.outputs.version }}
+          tag_name: v${{ needs.get_version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            src-tauri/target/release/bundle/msi/eCaptureQ_*.msi
+            src-tauri/target/release/bundle/nsis/eCaptureQ_*-setup.exe
+            src-tauri/target/release/bundle/dmg/eCaptureQ_*.dmg
+            src-tauri/target/release/bundle/appimage/eCaptureQ_*.AppImage
 
       - name: Publish Android Artifact
         if: matrix.platform == 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,11 +133,12 @@ jobs:
 
       - name: Initialize Tauri Android Project
         if: matrix.platform == 'android'
+        env:
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: pnpm tauri android init
 
       - name: Download and Setup eCapture (for Linux/Android build)
         shell: bash
-        # 因为你的 Rust 代码在编译 Android 时也需要 include_bytes!，所以这里也需要下载
         if: matrix.platform == 'linux' || matrix.platform == 'android'
         run: |
           echo ">>> Setting up eCapture for ${{ matrix.platform }}-${{ matrix.arch }}..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,8 +242,10 @@ jobs:
       - name: Sign APK
         if: matrix.platform == 'android'
         run: |
-          du -sh ./src-tauri/gen/android/release.decrypted.jks
-          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
+          ls -la src-tauri/gen/android/keystore.properties
+          ls -la src-tauri/gen/android/your-keystore.jks
+          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign \
+          --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
           src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
 
       - name: Rename APK file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
-
 on:
-  pull_request:
-    branches: [ main, develop ]
-    types: [opened, synchronize, reopened]
+  push:
+    tags:
+      - "v*"
 
 permissions: write-all
 
@@ -36,7 +35,7 @@ jobs:
           echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
           if [[ "$TAG_REF" != "v$PKG_VERSION" ]]; then
             echo "Tag ($TAG_REF) does not match package.json version (v$PKG_VERSION)."
-            exit 0
+            exit 1
           fi
           echo "Tag and package.json version are consistent."
 
@@ -201,7 +200,7 @@ jobs:
   # Job 2: 专门用于交叉编译 Linux ARM
   build-linux-arm:
     name: Build and Release for Linux ARM
-    needs: [get_version]
+    needs: [get_version,build-artifacts]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,17 +241,25 @@ jobs:
 
       - name: Sign APK
         if: matrix.platform == 'android'
+        env:
+          ANDROID_SIGNING_RELEASE_KEY: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}
+          ANDROID_SIGNING_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS }}
+          ANDROID_SIGNING_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
+          ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
         run: |
           ls -la src-tauri/gen/android/keystore.properties
           ls -la src-tauri/gen/android/your-keystore.jks
           ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign \
           --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
+          --ks-key-alias env:ANDROID_SIGNING_RELEASE_KEY_ALIAS \
+          --ks-pass env:ANDROID_SIGNING_RELEASE_KEY_PASSWORD \
+          --key-pass env:ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD \
+          --v1-signing-enabled true \
+          --v2-signing-enabled true \
+          --v3-signing-enabled true \
+          --verbose \
+          --out "./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk" \
           src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
-
-      - name: Rename APK file
-        if: matrix.platform == 'android'
-        run: |
-          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
 
       - name: Publish
         if: matrix.platform == 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,6 @@ jobs:
       - name: Pnpm install
         run: |
           pnpm i
-          pnpm run prebuild ${{ matrix.target }}
 
       - name: eCaptureQ build (non-Android)
         if: matrix.platform != 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,13 +185,13 @@ jobs:
           mkdir -p src-tauri/gen/android
 
           # 将 Base64 编码的密钥文件解码，并保存到 Runner 的临时目录
-          echo "${{ secrets.ANDROID_SIGNING_DEBUG_KEY }}" | base64 --decode > android_keystore.jks
+          echo "${{ secrets.ANDROID_SIGNING_DEBUG_KEY }}" | base64 --decode > src-tauri/gen/android/release.decrypted.jks
 
           # 将签名信息写入 keystore.properties 文件
           cat <<EOF > src-tauri/gen/android/keystore.properties
           password=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_ALIAS }}
-          storeFile=${{ github.workspace }}/android_keystore.jks
+          storeFile=${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks
           keyPassword=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_ALIAS_PASSWORD }}
           EOF
         env:
@@ -204,7 +204,7 @@ jobs:
 
       - name: eCaptureQ build (non-Android)
         if: matrix.platform != 'android'
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.5.22
         env:
           DECOUPLED_MODE: true
           RUST_TARGET: ${{ matrix.target }}
@@ -219,11 +219,11 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: v__VERSION__
-          releaseName: "eCaptureQ v__VERSION__"
+          tagName: v${{ steps.get_version.outputs.version }}
+          appName: eCaptureQ
+          appVersion: ${{ steps.get_version.outputs.version }}
+          releaseName: "eCaptureQ v${{ steps.get_version.outputs.version }}"
           releaseBody: "More new features are now supported."
-          appVersion: v__VERSION__
-          tauriScript: pnpm
 
       - name: eCaptureQ build (Android) ${{ matrix.arch }}
         if: matrix.platform == 'android'
@@ -235,6 +235,24 @@ jobs:
           pnpm tauri android build --target ${{ matrix.arch }}
 
       - name: Sign APK
+        if: matrix.platform == 'android'
         run: |
-          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks src-tauri/gen/android/release.decrypted.jks \
+          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
           src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
+
+
+      - name: Rename APK file
+        if: matrix.platform == 'android'
+        run: |
+          mv ./src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-signed.apk ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
+
+      - name: Publish
+        if: matrix.platform == 'android'
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          name: eCaptureQ v${{ steps.get_version.outputs.version }}
+          tag_name: v${{ steps.get_version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaptureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,42 +51,10 @@ jobs:
           fi
           echo "Tag and package.json version are consistent."
 
-  generate-changelog:
-    name: Generate Changelog
-    runs-on: ubuntu-latest
-    needs: check_tag_version
-    outputs:
-      changelog: ${{ steps.changelog.outputs.log }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # 获取所有历史记录以访问所有 tags
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          # 获取最新的两个 tag
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          PREVIOUS_TAG=$(git describe --tags `git rev-list --tags --skip=1 --max-count=1`)
-          
-          echo "Latest Tag: $LATEST_TAG"
-          echo "Previous Tag: $PREVIOUS_TAG"
-          
-          # 生成这两个 tag 之间的 commit log
-          LOG_CONTENT=$(git log ${PREVIOUS_TAG}..${LATEST_TAG} --pretty=format:"* %s (%h)")
-          
-          # 处理多行字符串以便输出
-          LOG_CONTENT="${LOG_CONTENT//'%'/'%25'}"
-          LOG_CONTENT="${LOG_CONTENT//$'\n'/'%0A'}"
-          LOG_CONTENT="${LOG_CONTENT//$'\r'/'%0D'}"
-          
-          echo "log=$LOG_CONTENT" >> $GITHUB_OUTPUT
-
   # 任务 2: 为 Windows, macOS, Linux, 和 Android 构建和发布
   build-artifacts:
     name: Build and Release
-    needs: [check_tag_version, generate-changelog]
+    needs: [check_tag_version]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,9 @@ jobs:
           appName: eCaptureQ
           appVersion: ${{ github.ref }}
           releaseName: "eCaptureQ v${{ github.ref }}"
-          releaseBody: "${{ needs.generate-changelog.outputs.changelog }}"
+          releaseBody: ""
+          releaseDraft: true
+          prerelease: 'false'
 
       - name: eCaptureQ build (Android) ${{ matrix.arch }}
         if: matrix.platform == 'android'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,5 @@
 name: Release
 
-# 验证是否正确，先使用PR 的触发条件
-#on:
-#  push:
-#    branches:
-#      - main
-#      - master
-#    tags:
-#      - "v*.*.*"
 on:
   pull_request:
     branches: [ main, develop ]
@@ -19,13 +11,11 @@ concurrency:
   group: "${{ github.workflow }} - ${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
-# 定义环境变量
 env:
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: short
 
 jobs:
-  # 任务 1: 检查 Git Tag 和 package.json 的版本是否一致
   get_version:
     name: Check Release Tag and package.json Version Consistency
     runs-on: ubuntu-latest
@@ -34,10 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Install jq for JSON parsing
         run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Get version from package.json
         id: get_version
         run: |
@@ -52,16 +40,13 @@ jobs:
           fi
           echo "Tag and package.json version are consistent."
 
-  # 任务 2: 为 Windows, macOS, Linux, 和 Android 构建和发布
   build-artifacts:
     name: Build and Release
     needs: [get_version]
     strategy:
       fail-fast: false
       matrix:
-        # 定义需要构建的平台和架构
         include:
-          # Windows
           - os: windows-latest
             platform: windows
             target: x86_64-pc-windows-msvc
@@ -70,7 +55,6 @@ jobs:
             platform: windows
             target: aarch64-pc-windows-msvc
             arch: aarch64
-          # macOS
           - os: macos-latest
             platform: macos
             target: aarch64-apple-darwin
@@ -79,7 +63,6 @@ jobs:
             platform: macos
             target: x86_64-apple-darwin
             arch: x86_64
-          # Linux
           - os: ubuntu-22.04
             platform: linux
             target: x86_64-unknown-linux-gnu
@@ -88,7 +71,6 @@ jobs:
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: aarch64
-          # Android
           - os: ubuntu-22.04
             platform: android
             target: x86_64-linux-android
@@ -102,7 +84,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # 安装 Rust Stable
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable
 
@@ -113,7 +94,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      # 下载并配置 Android SDK/NDK
       - name: Setup Android SDK
         if: matrix.platform == 'android'
         uses: android-actions/setup-android@v3
@@ -126,15 +106,12 @@ jobs:
         if: matrix.platform == 'android'
         run: sdkmanager "ndk;26.1.10909125"
 
-      # 添加 Rust 编译目标
       - name: Add Rust Target
         run: rustup target add ${{ matrix.target }}
 
-      # Rust 缓存
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      # 仅在 Ubuntu 上安装依赖
       - name: Install dependencies (ubuntu only)
         if: matrix.os == 'ubuntu-22.04'
         run: |
@@ -150,88 +127,54 @@ jobs:
           else
             ECAPTURE_ARCH="arm64"
           fi
-          pwd
           ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
-          if [[ $? -ne 0 ]]; then
-            echo "Failed to fetch the latest release."
-            exit 1
-          fi
-
           ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}.tar.gz"
           ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}"
-
-          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
-          tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
-
+          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || exit 1
+          tar -zxvf "${ECAPTURE_TAR}" || exit 1
           mkdir -p src-tauri/binaries
-          cp "${ECAPTURE_DIR}/ecapture" src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH} || { echo "Copy failed"; exit 1; }
-          ls src-tauri/binaries/
+          cp "${ECAPTURE_DIR}/ecapture" src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH} || exit 1
 
-      # 设置 Node.js 环境
       - name: Install Node
         uses: actions/setup-node@v4
         with:
           node-version: "22"
 
-      # 设置 pnpm
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: latest
 
-      # 安装前端依赖
       - name: Pnpm install
-        run: |
-          pnpm i
+        run: pnpm i
 
       - name: Create keystore.properties for Android signing
         if: matrix.platform == 'android'
         run: |
-          # 动态创建 src-tauri/gen/android 目录（如果不存在）
-          pwd
           pnpm tauri android init
-          mkdir -p src-tauri/gen/android
-
-          # 将 Base64 编码的密钥文件解码，并保存到 Runner 的临时目录
-          echo "${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}" | base64 --decode > src-tauri/gen/android/release.decrypted.jks
-
-          # 将签名信息写入 keystore.properties 文件
+          echo "${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}" | base64 --decode > release.decrypted.jks
           cat <<EOF > src-tauri/gen/android/keystore.properties
           password=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS }}
-          storeFile=${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks
+          storeFile=${{ github.workspace }}/release.decrypted.jks
           keyPassword=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
           EOF
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
-          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
-
 
       - name: eCaptureQ build (non-Android)
         if: matrix.platform != 'android'
-        uses: tauri-apps/tauri-action@v0.5.22
+        uses: tauri-apps/tauri-action@v0
         env:
-          DECOUPLED_MODE: true
-          RUST_TARGET: ${{ matrix.target }}
-          NODE_OPTIONS: "--max_old_space_size=4096"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: v${{ steps.get_version.outputs.version }}
-          appName: eCaptureQ
-          appVersion: ${{ steps.get_version.outputs.version }}
-          releaseName: "eCaptureQ v${{ steps.get_version.outputs.version }}"
+          tagName: v${{ needs.get_version.outputs.version }}
+          releaseName: "eCaptureQ v${{ needs.get_version.outputs.version }}"
           releaseBody: ""
           releaseDraft: true
-          prerelease: 'false'
+          prerelease: false
 
+      # [修改] 构建并自动签名安卓应用
       - name: eCaptureQ build (Android) ${{ matrix.arch }}
         if: matrix.platform == 'android'
         env:
@@ -239,35 +182,21 @@ jobs:
         run: |
           pnpm tauri android build --target ${{ matrix.arch }}
 
-      - name: Sign APK
-        if: matrix.platform == 'android'
-        env:
-          ANDROID_SIGNING_RELEASE_KEY: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}
-          ANDROID_SIGNING_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS }}
-          ANDROID_SIGNING_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
-          ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
-        run: |
-          ls -la src-tauri/gen/android/keystore.properties
-          ls -la src-tauri/gen/android/release.decrypted.jks
-          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign \
-          --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
-          --ks-key-alias env:ANDROID_SIGNING_RELEASE_KEY_ALIAS \
-          --ks-pass env:ANDROID_SIGNING_RELEASE_KEY_PASSWORD \
-          --key-pass env:ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD \
-          --v1-signing-enabled true \
-          --v2-signing-enabled true \
-          --v3-signing-enabled true \
-          --verbose \
-          --out "./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaprureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk" \
-          src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
+      # [删除] 整个手动签名的步骤被删除，因为上一步已经自动完成了
 
+      # [新增] 重命名已签名的 APK 以便发布
+      - name: Rename Artifact
+        if: matrix.platform == 'android'
+        run: |
+          mv src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk ./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk
+
+      # [修改] 发布重命名后的 APK 文件
       - name: Publish
         if: matrix.platform == 'android'
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          name: eCaptureQ v${{ steps.get_version.outputs.version }}
-          tag_name: v${{ steps.get_version.outputs.version }}
+          name: eCaptureQ v${{ needs.get_version.outputs.version }}
+          tag_name: v${{ needs.get_version.outputs.version }}
           generate_release_notes: true
-          files: |
-            ./src-tauri/gen/android/app/build/outputs/apk/universal/release/eCaptureQ_v${{ steps.get_version.outputs.version }}_${{ matrix.arch }}.apk
+          files: ./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,8 +116,9 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev libgtk-3-dev libssl-dev xdg-utils librsvg2-dev libappindicator3-dev  patchelf
+          sudo apt-get install -y libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev libgtk-3-dev libssl-dev xdg-utils librsvg2-dev libappindicator3-dev patchelf
 
+      # [修正] 修正了 ecapture 的下载逻辑
       - name: Download and setup eCapture for ${{ matrix.arch }}
         shell: bash
         if: matrix.platform == 'linux' || matrix.platform == 'android'
@@ -127,13 +128,39 @@ jobs:
           else
             ECAPTURE_ARCH="arm64"
           fi
+          
+          # 判断平台，如果是 android，则下载 linux 版本的 ecapture
+          ECAPTURE_PLATFORM="${{ matrix.platform }}"
+          if [[ "${{ matrix.platform }}" == "android" ]]; then
+            echo "Android platform detected. Using 'linux' binaries for eCapture."
+            ECAPTURE_PLATFORM="linux"
+          fi
+          
           ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
-          ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}.tar.gz"
-          ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}"
-          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || exit 1
-          tar -zxvf "${ECAPTURE_TAR}" || exit 1
+          if [[ -z "$ECAPTURE_LATEST" ]]; then
+            echo "Failed to fetch the latest eCapture release version."
+            exit 1
+          fi
+
+          ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${ECAPTURE_PLATFORM}-${ECAPTURE_ARCH}.tar.gz"
+          ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-${ECAPTURE_PLATFORM}-${ECAPTURE_ARCH}"
+
+          echo "Downloading: ${ECAPTURE_TAR}"
+          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
+          
+          echo "Extracting from: ${ECAPTURE_TAR}"
+          tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
+
           mkdir -p src-tauri/binaries
-          cp "${ECAPTURE_DIR}/ecapture" src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH} || exit 1
+          
+          SOURCE_FILE="${ECAPTURE_DIR}/ecapture"
+          DEST_FILE="src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
+          
+          echo "Copying from ${SOURCE_FILE} to ${DEST_FILE}"
+          cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
+          
+          echo "Contents of binaries directory:"
+          ls src-tauri/binaries/
 
       - name: Install Node
         uses: actions/setup-node@v4
@@ -148,19 +175,23 @@ jobs:
       - name: Pnpm install
         run: pnpm i
 
+      # [修正] 为此步骤添加了 NDK_HOME 环境变量
       - name: Create keystore.properties for Android signing
         if: matrix.platform == 'android'
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: |
           pnpm tauri android init
           echo "${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}" | base64 --decode > release.decrypted.jks
+          # 确保目录存在，增加稳健性
+          mkdir -p src-tauri/gen/android
           cat <<EOF > src-tauri/gen/android/keystore.properties
           password=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS }}
           storeFile=${{ github.workspace }}/release.decrypted.jks
           keyPassword=${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
           EOF
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: eCaptureQ build (non-Android)
         if: matrix.platform != 'android'
@@ -174,7 +205,6 @@ jobs:
           releaseDraft: true
           prerelease: false
 
-      # [修改] 构建并自动签名安卓应用
       - name: eCaptureQ build (Android) ${{ matrix.arch }}
         if: matrix.platform == 'android'
         env:
@@ -182,16 +212,12 @@ jobs:
         run: |
           pnpm tauri android build --target ${{ matrix.arch }}
 
-      # [删除] 整个手动签名的步骤被删除，因为上一步已经自动完成了
-
-      # [新增] 重命名已签名的 APK 以便发布
-      - name: Rename Artifact
+      - name: Rename Android Artifact
         if: matrix.platform == 'android'
         run: |
           mv src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk ./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk
 
-      # [修改] 发布重命名后的 APK 文件
-      - name: Publish
+      - name: Publish Android Artifact
         if: matrix.platform == 'android'
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,28 @@
-name: PR Build and Test
+name: Release
 
+# 验证是否正确，先使用PR 的触发条件
+#on:
+#  push:
+#    branches:
+#      - main
+#      - master
+#    tags:
+#      - "v*.*.*"
 on:
   pull_request:
     branches: [ main, develop ]
     types: [opened, synchronize, reopened]
 
-# 授予工作流写入权限，用于创建 Release 和上传产物
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: write-all
+
+concurrency:
+  group: "${{ github.workflow }} - ${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
 
 # 定义环境变量
 env:
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: short
-
-# 确保每个提交只运行一次工作流
-concurrency:
-  group: "${{ github.workflow }} - ${{ github.head_ref || github.ref }}"
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # 任务 1: 检查 Git Tag 和 package.json 的版本是否一致
@@ -38,12 +41,18 @@ jobs:
       - name: Get version from package.json
         id: get_version
         run: |
+          TAG_REF="${GITHUB_REF##*/}"
+          echo "Current tag: $TAG_REF"
           PKG_VERSION=$(jq -r .version package.json)
           echo "package.json version: $PKG_VERSION"
-          echo "version=${PKG_VERSION}" >> $GITHUB_OUTPUT
+          if [[ "$TAG_REF" != "v$PKG_VERSION" ]]; then
+            echo "Tag ($TAG_REF) does not match package.json version (v$PKG_VERSION)."
+            exit 1
+          fi
+          echo "Tag and package.json version are consistent."
 
   # 任务 2: 为 Windows, macOS, Linux, 和 Android 构建和发布
-  build-debug-artifacts:
+  build-artifacts:
     name: Build and Release
     needs: check_tag_version
     strategy:
@@ -78,7 +87,15 @@ jobs:
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: aarch64
-
+          # Android
+          - os: ubuntu-22.04
+            platform: android
+            target: x86_64
+            arch: x86_64
+          - os: ubuntu-22.04
+            platform: android
+            target: aarch64
+            arch: aarch64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
@@ -87,6 +104,26 @@ jobs:
       # 安装 Rust Stable
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Java
+        if: matrix.platform == 'android'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '23'
+
+      # 下载并配置 Android SDK/NDK
+      - name: Setup Android SDK
+        if: matrix.platform == 'android'
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+          ndk-version: 26.1.10909125
+
+      - name: Install NDK
+        if: matrix.platform == 'android'
+        run: sdkmanager "ndk;26.1.10909125"
 
       # 添加 Rust 编译目标
       - name: Add Rust Target
@@ -105,7 +142,7 @@ jobs:
 
       - name: Download and setup eCapture for ${{ matrix.arch }}
         shell: bash
-        if: matrix.platform == 'linux'
+        if: matrix.platform == 'linux' || matrix.platform == 'android'
         run: |
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
             ECAPTURE_ARCH="amd64"
@@ -134,77 +171,69 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-      
+
       # 设置 pnpm
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: latest
 
+      - name: Create keystore.properties for Android signing
+        if: matrix.platform == 'android'
+        run: |
+          # 动态创建 src-tauri/gen/android 目录（如果不存在）
+          mkdir -p src-tauri/gen/android
+
+          # 将 Base64 编码的密钥文件解码，并保存到 Runner 的临时目录
+          echo "${{ secrets.ANDROID_SIGNING_DEBUG_KEY }}" | base64 --decode > android_keystore.jks
+
+          # 将签名信息写入 keystore.properties 文件
+          cat <<EOF > src-tauri/gen/android/keystore.properties
+          password=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_ALIAS }}
+          storeFile=${{ github.workspace }}/android_keystore.jks
+          keyPassword=${{ secrets.ANDROID_SIGNING_DEBUG_KEY_ALIAS_PASSWORD }}
+          EOF
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
       # 安装前端依赖
       - name: Pnpm install
-        run: pnpm i
-
-      # Tauri 构建
-      - name: Tauri build (Linux)
-        if: matrix.platform == 'linux'
-        env:
-          DECOUPLED_MODE: true
         run: |
-            pnpm tauri build
-      - name: Tauri build (macOS/Windows)
-        if: matrix.platform != 'linux'
+          pnpm i
+          pnpm run prebuild ${{ matrix.target }}
+
+      - name: eCaptureQ build (non-Android)
+        if: matrix.platform != 'android'
+        uses: tauri-apps/tauri-action@v0
         env:
-          DECOUPLED_MODE: true
+          NODE_OPTIONS: "--max_old_space_size=4096"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: v__VERSION__
+          releaseName: "eCaptureQ v__VERSION__"
+          releaseBody: "More new features are now supported."
+          tauriScript: pnpm
+          args: --target ${{ matrix.target }}
+
+      - name: eCaptureQ build (Android) ${{ matrix.arch }}
+        if: matrix.platform == 'android'
+        env:
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: |
-          pnpm tauri build
+          rm -rf src-tauri/gen/android
+          pnpm tauri android init
+          pnpm tauri android build --target ${{ matrix.arch }}
 
-      - name: Upload artifacts (Linux)
-        uses: actions/upload-artifact@v4
-        if: matrix.platform == 'linux'
-        with:
-          name: eCaptureQ-pr${{ github.event.number }}-${{ github.run_id }}-${{ matrix.arch }}.AppImage
-          retention-days: 7
-          path: src-tauri/target/release/bundle/appimage/eCaptureQ*.AppImage
-
-      - name: Upload artifacts (macOS)
-        uses: actions/upload-artifact@v4
-        if: matrix.platform == 'macos'
-        with:
-          name: eCaptureQ-pr${{ github.event.number }}-${{ github.run_id }}-${{ matrix.arch }}.dmg
-          retention-days: 7
-          path: |
-            src-tauri/target/release/bundle/dmg/eCaptureQ*.dmg
-
-      - name: Upload artifacts (Windows)
-        uses: actions/upload-artifact@v4
-        if: matrix.platform == 'windows'
-        with:
-          name: eCaptureQ-pr${{ github.event.number }}-${{ github.run_id }}-${{ matrix.arch }}.msi
-          retention-days: 7
-          path: |
-            src-tauri/target/release/bundle/msi/eCaptureQ*.msi
-
-  comment-pr:
-    runs-on: ubuntu-22.04
-    name: Comment PR with Download Links
-    needs: build-debug-artifacts
-    steps:
-      - name: Comment PR with Download Links
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const runId = context.runId;
-            const prNumber = context.payload.pull_request.number;
-
-            github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🔧 **Debug Build Complete (macOS、Linux、Windows)**
-
-              📦 Download Links:
-              - [PR ${prNumber} Debug Binary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})
-
-              ⏰ Files will be retained for 7 days, please download and test promptly.`
-            });
+      - name: Sign APK
+        run: |
+          ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign --ks src-tauri/gen/android/release.decrypted.jks \
+          src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,6 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable
 
-      # ... Android 相关步骤保持不变 ...
       - name: Set up Java
         if: matrix.platform == 'android'
         uses: actions/setup-java@v4
@@ -104,7 +103,6 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      # 这个步骤现在只为 x86_64 Linux 安装原生依赖
       - name: Install dependencies (ubuntu x86_64 only)
         if: matrix.platform == 'linux'
         run: |
@@ -122,7 +120,6 @@ jobs:
       - name: Pnpm install
         run: pnpm i
 
-      # ... Android 初始化步骤保持不变 ...
       - name: Initialize Tauri Android Project
         if: matrix.platform == 'android'
         env:
@@ -133,7 +130,6 @@ jobs:
         shell: bash
         if: matrix.platform == 'linux' || matrix.platform == 'android'
         run: |
-          # 这部分逻辑现在对于这个 Job 来说总是正确的
           echo ">>> Setting up eCapture for ${{ matrix.platform }}-${{ matrix.arch }}..."
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
             ECAPTURE_ARCH="amd64"
@@ -151,12 +147,10 @@ jobs:
           cp "${SOURCE_FILE}" "${DEST_FILE}"
           ls -l src-tauri/binaries/
 
-      # --- 修改点: 为所有桌面构建添加 --target 参数 ---
       - name: Build Desktop Artifacts (Windows/macOS/Linux)
         if: matrix.platform != 'android'
         run: pnpm tauri build --target ${{ matrix.target }}
 
-      # ... Android 构建和发布步骤保持不变 ...
       - name: Build Android Artifact
         if: matrix.platform == 'android'
         env:
@@ -189,7 +183,6 @@ jobs:
           generate_release_notes: true
           files: ./eCaptureQ_v${{ needs.get_version.outputs.version }}_${{ matrix.arch }}.apk
 
-      # --- 修改点: 确保文件路径正确匹配 target ---
       - name: Publish Desktop Artifacts
         if: matrix.platform != 'android'
         uses: softprops/action-gh-release@v1
@@ -205,7 +198,7 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/eCaptureQ_*.AppImage
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
 
-  # --- 新增 Job: 专门用于交叉编译 Linux ARM ---
+  # Job 2: 专门用于交叉编译 Linux ARM
   build-linux-arm:
     name: Build and Release for Linux ARM
     needs: [get_version]
@@ -240,24 +233,29 @@ jobs:
       - name: Pnpm install
         run: pnpm i
 
-      # --- 核心步骤: 设置交叉编译环境 ---
+      # --- 修正后的核心步骤: 设置交叉编译环境 ---
       - name: Setup cross-compilation environment for Linux ARM
         run: |
-          # 1. 添加 ARM 架构支持
-          sudo dpkg --add-architecture arm64
-          # 2. 修改 apt 源，使其能找到 ARM 架构的包
-          # 使用 sed 在现有源的每一行末尾添加 [arch=amd64] 
-          sudo sed -i -e 's/$/ \[arch=amd64\]/' /etc/apt/sources.list
-          # 添加 ARM 的源
-          cat <<EOF | sudo tee -a /etc/apt/sources.list
+          # 1. 创建全新的、格式正确的 sources.list 文件
+          cat > /tmp/sources.list << EOF
+          deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
+          deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
+          deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
+          deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
           EOF
+          
+          # 2. 备份旧文件并替换为新文件
+          sudo mv /etc/apt/sources.list /etc/apt/sources.list.bak
+          sudo mv /tmp/sources.list /etc/apt/sources.list
+          
+          # 3. 添加 ARM 架构支持并更新
+          sudo dpkg --add-architecture arm64
           sudo apt-get update
 
-      # --- 核心步骤: 安装 aarch64 版本的依赖库 ---
       - name: Install ARM dependencies
         run: |
           sudo apt-get install -y \
@@ -271,7 +269,6 @@ jobs:
             libappindicator3-dev:arm64 \
             patchelf:arm64
 
-      # --- 核心步骤: 安装 C 语言的交叉编译器 ---
       - name: Install C cross-compiler for aarch64
         run: sudo apt-get install -y gcc-aarch64-linux-gnu
 
@@ -289,15 +286,12 @@ jobs:
           cp "${SOURCE_FILE}" "${DEST_FILE}"
           ls -l src-tauri/binaries/
 
-      # --- 核心步骤: 执行交叉编译，并设置所需的环境变量 ---
       - name: Build Linux ARM Artifact
         env:
-          # 设置 pkg-config 环境变量，让构建系统能找到 aarch64 的库
           PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
           PKG_CONFIG_ALLOW_CROSS: 1
         run: pnpm tauri build --target ${{ matrix.target }}
 
-      # --- 新增步骤: 为这个 Job 单独发布产物 ---
       - name: Publish Linux ARM Artifacts
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev libgtk-3-dev libssl-dev xdg-utils librsvg2-dev libappindicator3-dev patchelf
 
-      - name: Download and setup eCapture for ${{ matrix.arch }}
+      - name: Download and setup eCapture
         shell: bash
         if: matrix.platform == 'linux' || matrix.platform == 'android'
         run: |
@@ -128,30 +128,29 @@ jobs:
             ECAPTURE_ARCH="arm64"
           fi
           
-          ECAPTURE_PLATFORM="${{ matrix.platform }}"
-          if [[ "${{ matrix.platform }}" == "android" ]]; then
-            echo "Android platform detected. Using 'linux' binaries for eCapture."
-            ECAPTURE_PLATFORM="linux"
-          fi
-          
           ECAPTURE_LATEST=$(curl -s https://api.github.com/repos/gojue/ecapture/releases/latest | grep tag_name | cut -d '"' -f 4)
           if [[ -z "$ECAPTURE_LATEST" ]]; then
             echo "Failed to fetch the latest eCapture release version."
             exit 1
           fi
 
-          ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${ECAPTURE_PLATFORM}-${ECAPTURE_ARCH}.tar.gz"
-          ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-${ECAPTURE_PLATFORM}-${ECAPTURE_ARCH}"
+          # This logic now correctly uses the platform name from the matrix
+          ECAPTURE_TAR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}.tar.gz"
+          ECAPTURE_DIR="ecapture-${ECAPTURE_LATEST}-${{ matrix.platform }}-${ECAPTURE_ARCH}"
 
-          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download failed"; exit 1; }
+          wget "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_LATEST}/${ECAPTURE_TAR}" || { echo "Download for ${{ matrix.platform }} failed"; exit 1; }
           tar -zxvf "${ECAPTURE_TAR}" || { echo "Extract failed"; exit 1; }
-          mkdir -p src-tauri/binaries
+          
+          # Place the binary in the root `binaries/` directory as required by the Rust code
+          mkdir -p binaries
           
           SOURCE_FILE="${ECAPTURE_DIR}/ecapture"
-          DEST_FILE="src-tauri/binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
+          DEST_FILE="binaries/${{ matrix.platform }}_ecapture_${ECAPTURE_ARCH}"
           
           cp "${SOURCE_FILE}" "${DEST_FILE}" || { echo "Copy failed"; exit 1; }
-          ls src-tauri/binaries/
+          
+          echo "Contents of binaries directory:"
+          ls -l binaries/
 
       - name: Install Node
         uses: actions/setup-node@v4
@@ -170,7 +169,7 @@ jobs:
         if: matrix.platform == 'android'
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
-          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125 # <-- 这里采纳了您范例中的正确设置
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/26.1.10909125
         run: |
           pnpm tauri android init
           echo "${{ secrets.ANDROID_SIGNING_RELEASE_KEY }}" | base64 --decode > release.decrypted.jks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
           ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.ANDROID_SIGNING_RELEASE_KEY_ALIAS_PASSWORD }}
         run: |
           ls -la src-tauri/gen/android/keystore.properties
-          ls -la src-tauri/gen/android/your-keystore.jks
+          ls -la src-tauri/gen/android/release.decrypted.jks
           ${{ env.ANDROID_HOME }}/build-tools/34.0.0/apksigner sign \
           --ks ${{ github.workspace }}/src-tauri/gen/android/release.decrypted.jks \
           --ks-key-alias env:ANDROID_SIGNING_RELEASE_KEY_ALIAS \

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf dist node_modules .turbo && pnpm install",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build",
+    "tauri:build": "tsc && vite build && tauri build",
     "tauri:build:decoupled": "cross-env DECOUPLED_MODE=true pnpm tauri build",
     "android:build": "tauri android build --target aarch64",
     "android:init": "tauri android init"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ecaptureq",
+  "name": "eaptureq",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,8 @@ wg = { version = "0.9.2", features = ["future"] }
 
 # Build profile for release: optimize for size
 [profile.release]
-opt-level = "s"      # Optimize for size
+opt-level = "z"      # Optimize for size
 lto = true             # Enable Link Time Optimization
+codegen-units = 1    # Slower builds, but better optimization
+panic = "abort"      # Abort on panic to reduce binary size
 strip = true           # Strip symbols from the final binary

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,8 +36,8 @@ wg = { version = "0.9.2", features = ["future"] }
 
 # Build profile for release: optimize for size
 [profile.release]
-opt-level = "s"      # Optimize for size
-lto = true             # Enable Link Time Optimization
-codegen-units = 1    # Slower builds, but better optimization
-panic = "abort"      # Abort on panic to reduce binary size
-strip = true           # Strip symbols from the final binary
+#opt-level = "s"      # Optimize for size
+#lto = true             # Enable Link Time Optimization
+#codegen-units = 1    # Slower builds, but better optimization
+#panic = "abort"      # Abort on panic to reduce binary size
+#strip = true           # Strip symbols from the final binary

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,8 +36,8 @@ wg = { version = "0.9.2", features = ["future"] }
 
 # Build profile for release: optimize for size
 [profile.release]
-#opt-level = "s"      # Optimize for size
-#lto = true             # Enable Link Time Optimization
-#codegen-units = 1    # Slower builds, but better optimization
-#panic = "abort"      # Abort on panic to reduce binary size
-#strip = true           # Strip symbols from the final binary
+opt-level = "s"      # Optimize for size
+lto = true             # Enable Link Time Optimization
+codegen-units = 1    # Slower builds, but better optimization
+panic = "abort"      # Abort on panic to reduce binary size
+strip = true           # Strip symbols from the final binary

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ wg = { version = "0.9.2", features = ["future"] }
 
 # Build profile for release: optimize for size
 [profile.release]
-opt-level = "z"      # Optimize for size
+opt-level = "s"      # Optimize for size
 lto = true             # Enable Link Time Optimization
 codegen-units = 1    # Slower builds, but better optimization
 panic = "abort"      # Abort on panic to reduce binary size

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,7 @@ pub async fn run() {
         })
         .manage(app_state)
         .plugin(log_plugin)
+        .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             commands::start_capture,
             commands::stop_capture,

--- a/src-tauri/src/services/capture.rs
+++ b/src-tauri/src/services/capture.rs
@@ -56,36 +56,37 @@ fn get_cli_binary_name() -> String {
 
     "ecapture".to_string()
 }
+
+// Android x86_64
+#[cfg(all(target_os = "android", target_arch = "x86_64"))]
 fn get_ecapture_bytes() -> &'static [u8] {
-    // Android x86_64
-    #[cfg(all(target_os = "android", target_arch = "x86_64"))]
-    {
-        return include_bytes!("../../binaries/android_ecapture_amd64");
-    }
-
-    // Android arm64
-    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
-    {
-        return include_bytes!("../../binaries/android_ecapture_arm64");
-    }
-
-    // Linux x86_64
-    #[cfg(all(target_os = "linux", target_arch = "x86_64", not(decoupled)))]
-    {
-        return include_bytes!("../../binaries/linux_ecapture_amd64");
-    }
-
-    // Linux arm64
-    #[cfg(all(target_os = "linux", target_arch = "aarch64", not(decoupled)))]
-    {
-        return include_bytes!("../../binaries/linux_ecapture_arm64");
-    }
-
-    #[cfg(any(all(not(target_os = "linux"), not(target_os = "android")), decoupled))]
-    {
-        panic!("Unsupported platform or architecture");
-    }
+    include_bytes!("../../binaries/android_ecapture_amd64")
 }
+
+// Android arm64
+#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+fn get_ecapture_bytes() -> &'static [u8] {
+    include_bytes!("../../binaries/android_ecapture_arm64")
+}
+
+// Linux x86_64
+#[cfg(all(target_os = "linux", target_arch = "x86_64", not(decoupled)))]
+fn get_ecapture_bytes() -> &'static [u8] {
+    include_bytes!("../../binaries/linux_ecapture_amd64")
+}
+
+// Linux arm64
+#[cfg(all(target_os = "linux", target_arch = "aarch64", not(decoupled)))]
+fn get_ecapture_bytes() -> &'static [u8] {
+    include_bytes!("../../binaries/linux_ecapture_arm64")
+}
+
+// Fallback for unsupported platforms.
+#[cfg(any(all(not(target_os = "linux"), not(target_os = "android")), decoupled))]
+fn get_ecapture_bytes() -> &'static [u8] {
+    panic!("Unsupported platform or architecture");
+}
+
 pub struct CaptureManager {
     executable_path: PathBuf,
     child: Option<Child>,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
     "withGlobalTauri": false
   },
   "bundle": {
+    "outputName": "{{name}}_{{version}}_{{arch}}",
     "active": true,
     "targets": ["deb", "rpm", "appimage", "nsis", "msi", "app", "dmg"],
     "icon": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["deb", "rpm", "appimage", "nsis", "msi", "app", "dmg"],
+    "targets": ["deb", "rpm", "nsis", "msi", "app", "dmg"],
     "icon": [
       "icons/32x32.png",
       "icons/64x64.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,12 +39,6 @@
       "icons/icon.ico",
       "icons/icon.png"
     ],
-    "android": {
-      "keystorePath": "./gen/android/keystore.properties",
-      "signing": {
-        "enabled": true
-      }
-    },
     "publisher": "gojue",
     "copyright": "Copyright © 2025 gojue",
     "homepage": "https://github.com/gojue/ecaptureQ",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,6 @@
     "withGlobalTauri": false
   },
   "bundle": {
-    "outputName": "{{name}}_{{version}}_{{arch}}",
     "active": true,
     "targets": ["deb", "rpm", "appimage", "nsis", "msi", "app", "dmg"],
     "icon": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,12 @@
       "icons/icon.ico",
       "icons/icon.png"
     ],
+    "android": {
+      "keystorePath": "./gen/android/keystore.properties",
+      "signing": {
+        "enabled": true
+      }
+    },
     "publisher": "gojue",
     "copyright": "Copyright © 2025 gojue",
     "homepage": "https://github.com/gojue/ecaptureQ",


### PR DESCRIPTION
This pull request introduces a new `release.yml` GitHub Actions workflow to automate multi-platform release builds, and makes several improvements to the CI build scripts and Rust build configuration. The changes focus on unifying and simplifying artifact naming, optimizing Rust release builds, and adding new plugin functionality.

**CI/CD Workflows and Release Automation:**

* Added a new `.github/workflows/release.yml` workflow to automate building and releasing for Windows, macOS, Linux, and Android, including version consistency checks and platform-specific artifact handling.
* Updated artifact naming and copy logic in `.github/workflows/pr-build.yml` and `.github/workflows/pr_build_android.yml` to use standardized names based on `${{ matrix.platform }}` and `${ECAPTURE_ARCH}`. [[1]](diffhunk://#diff-404033996c34f9971e0c112d8538b9063618fc85059a44df7d4db448974888caL122-R129) [[2]](diffhunk://#diff-e406005717fbc98d961fe227dfbd29e8cec803c6a14f68ea98f6fa28e92883d8L55-R56)
* Cleaned up commented environment variables and unnecessary commands in `.github/workflows/pr_build_android.yml`.

**Rust Build Optimization:**

* Improved the `[profile.release]` section in `src-tauri/Cargo.toml` for smaller, more optimized binaries by switching to `opt-level = "z"`, enabling single codegen unit, abort-on-panic, and stripping symbols.

**Application Functionality:**

* Added the `tauri_plugin_opener` plugin initialization in `src-tauri/src/lib.rs` to extend application capabilities.