### PR TITLE
feat: Update version to 0.1.4; add entitlements for macOS and enhance README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Effortlessly capture TLS encrypted traffic in a cross-platform GUI using eBPF, w
 
 ## Overview
 
-eCaptureQ is a cross-platform GUI for [ecapture](https://github.com/gojue/ecapture), visualizing its eBPF-powered packet capturing capabilities: capture TLS plaintext at the kernel level without needing a CA certificate or MITM.
+eCaptureQ is a cross-platform GUI for [ecapture](https://github.com/gojue/ecaptureQ/releases), visualizing its eBPF-powered packet capturing capabilities: capture TLS plaintext at the kernel level without needing a CA certificate or MITM.
 
 This means you can debug and analyze the encrypted communications of any program in a simpler, more efficient, and non-intrusive way.
+
+https://github.com/user-attachments/assets/c8b7a84d-58eb-4fdb-9843-f775c97bdbfb
+
 
 ## Key Features
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -13,9 +13,11 @@
 
 ## 概览
 
-eCaptureQ 是 [eCapture](https://github.com/gojue/ecapture) 的跨平台 GUI，将其 eBPF 抓包能力以可视化方式呈现：无需 CA / MITM，在内核侧捕获 TLS 明文。
+eCaptureQ 是 [eCapture](https://github.com/gojue/ecaptureQ/releases) 的跨平台 GUI，将其 eBPF 抓包能力以可视化方式呈现：无需 CA / MITM，在内核侧捕获 TLS 明文。
 
 这意味着您可以更简单、更高效、更无侵入地调试和分析任何程序的加密通信。
+
+https://github.com/user-attachments/assets/c8b7a84d-58eb-4fdb-9843-f775c97bdbfb
 
 ## 主要特性
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eaptureq",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.application-identifier</key>
+    <string>2CJR2EP3SQ.com.gojue.ecaptureq</string>
+    <key>com.apple.developer.team-identifier</key>
+    <string>2CJR2EP3SQ</string>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eCaptureQ",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "identifier": "com.gojue.ecaptureq",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -40,7 +40,11 @@
       "icons/icon.png"
     ],
     "macOS": {
-      "minimumSystemVersion": "12.0"
+      "minimumSystemVersion": "12.0",
+      "entitlements": "entitlements.plist",
+      "files": {
+        "embedded.provisionprofile": "ecaptureq.provisionprofile"
+      }
     },
     "publisher": "gojue",
     "copyright": "Copyright © 2025 gojue",


### PR DESCRIPTION
This pull request updates versioning, documentation links, and macOS build configuration for the eCaptureQ project. The main changes include updating the application version, improving documentation links and visuals, and adding entitlements and provisioning settings for macOS builds.

**Version Updates:**

* Updated the application version from `0.1.1` to `0.1.4` in both `package.json` and `src-tauri/tauri.conf.json` to reflect the latest release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)

**Documentation Improvements:**

* Changed the eCapture project link in both `README.md` and `README_CN.md` to point to the release page for better user guidance, and added a visual asset link to enhance the overview section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R22) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L16-R21)

**macOS Build Configuration:**

* Added a new `entitlements.plist` file to specify required macOS app sandboxing and network permissions.
* Updated the `tauri.conf.json` macOS section to reference the entitlements file and include the embedded provisioning profile for proper code signing and distribution.