### PR TITLE
feat: Implement persistent configuration

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "eCaptureQ"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/src/tauri_bridge/state.rs
+++ b/src-tauri/src/tauri_bridge/state.rs
@@ -1,8 +1,14 @@
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock, watch};
 
 use crate::{core::actor::DataFrameActorHandle, services::push_service::PushServiceHandle};
+
+use anyhow::{Error, Result, anyhow};
+// use log::Level::Error;
+use tauri::Manager;
 
 #[derive(Clone)]
 pub enum RunState {
@@ -16,15 +22,57 @@ pub struct Configs {
     pub ecapture_args: Option<String>,
 }
 
+const CONFIG_FILE_NAME: &str = "config.json";
+
 impl Configs {
-    pub fn apply_patch(&mut self, patch: Configs) {
-        if let Some(ws_url) = patch.ws_url {
+    pub fn apply_patch(&mut self, patch: &mut Configs) {
+        if let Some(ws_url) = patch.ws_url.take() {
             self.ws_url = Some(ws_url);
         }
 
-        if let Some(ecapture_args) = patch.ecapture_args {
+        if let Some(ecapture_args) = patch.ecapture_args.take() {
             self.ecapture_args = Some(ecapture_args);
         }
+    }
+
+    fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+
+    fn from_json(json_str: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(json_str)
+    }
+
+    pub fn get_json_from_app_dir(base_path: impl AsRef<Path>) -> Result<Self> {
+        let json_data = fs::read_to_string(base_path.as_ref().join(CONFIG_FILE_NAME))?;
+        let configs = Self::from_json(json_data.as_str())?;
+        Ok(configs)
+    }
+
+    pub fn save_json_to_app_dir(&self, path: impl AsRef<Path>) -> Result<()> {
+        let json_data = self.to_json()?;
+        fs::write(path, json_data).map_err(Error::from)
+    }
+
+    pub fn init() -> Self {
+        Configs {
+            ws_url: Some("ws://127.0.0.1:28257".to_string()),
+            ecapture_args: Some(" tls --ecaptureq ws://127.0.0.1:28257".to_string()),
+        }
+    }
+}
+
+pub fn config_check(base_path: impl AsRef<Path>) -> Result<()> {
+    if base_path.as_ref().join(CONFIG_FILE_NAME).exists() {
+        if let Ok(_) = Configs::get_json_from_app_dir(&base_path) {
+            Ok(())
+        } else {
+            Configs::init().save_json_to_app_dir(&base_path)?;
+            Ok(())
+        }
+    } else {
+        Configs::init().save_json_to_app_dir(&base_path)?;
+        Ok(())
     }
 }
 
@@ -37,7 +85,14 @@ pub struct AppState {
     pub done: Mutex<watch::Sender<()>>,
 
     // runtime configs
-    pub configs: Mutex<Configs>,
+    pub configs: Mutex<Option<Configs>>,
 
     pub status: Arc<RwLock<RunState>>,
+}
+
+impl AppState {
+    pub async fn init_configs(&self, configs: Configs) {
+        //self.configs = Mutex::new(Some(configs))
+        *self.configs.lock().await = Some(configs)
+    }
 }

--- a/src-tauri/src/tauri_bridge/state.rs
+++ b/src-tauri/src/tauri_bridge/state.rs
@@ -64,16 +64,15 @@ impl Configs {
 }
 
 pub fn config_check(base_path: impl AsRef<Path>) -> Result<()> {
-    let path =base_path.as_ref().join(CONFIG_FILE_NAME);
-    if path.join(CONFIG_FILE_NAME).exists() {
-        if let Ok(_) = Configs::get_json_from_app_dir(&path) {
+    if base_path.as_ref().join(CONFIG_FILE_NAME).exists() {
+        if let Ok(_) = Configs::get_json_from_app_dir(&base_path) {
             Ok(())
         } else {
-            Configs::init().save_json_to_app_dir(&path)?;
+            Configs::init().save_json_to_app_dir(&base_path)?;
             Ok(())
         }
     } else {
-        Configs::init().save_json_to_app_dir(&path)?;
+        Configs::init().save_json_to_app_dir(&base_path)?;
         Ok(())
     }
 }

--- a/src-tauri/src/tauri_bridge/state.rs
+++ b/src-tauri/src/tauri_bridge/state.rs
@@ -49,7 +49,8 @@ impl Configs {
         Ok(configs)
     }
 
-    pub fn save_json_to_app_dir(&self, path: impl AsRef<Path>) -> Result<()> {
+    pub fn save_json_to_app_dir(&self, base_path: impl AsRef<Path>) -> Result<()> {
+        let path =base_path.as_ref().join(CONFIG_FILE_NAME);
         let json_data = self.to_json()?;
         fs::write(path, json_data).map_err(Error::from)
     }
@@ -63,15 +64,16 @@ impl Configs {
 }
 
 pub fn config_check(base_path: impl AsRef<Path>) -> Result<()> {
-    if base_path.as_ref().join(CONFIG_FILE_NAME).exists() {
-        if let Ok(_) = Configs::get_json_from_app_dir(&base_path) {
+    let path =base_path.as_ref().join(CONFIG_FILE_NAME);
+    if path.join(CONFIG_FILE_NAME).exists() {
+        if let Ok(_) = Configs::get_json_from_app_dir(&path) {
             Ok(())
         } else {
-            Configs::init().save_json_to_app_dir(&base_path)?;
+            Configs::init().save_json_to_app_dir(&path)?;
             Ok(())
         }
     } else {
-        Configs::init().save_json_to_app_dir(&base_path)?;
+        Configs::init().save_json_to_app_dir(&path)?;
         Ok(())
     }
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -141,11 +141,10 @@ export function SettingsPage() {
                 type="text"
                 value={configs.ws_url || ''}
                 onChange={(e) => updateConfigs({ ws_url: e.target.value })}
-                placeholder="ws://127.0.0.1:28257"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
               />
               <p className="text-xs text-gray-500 dark:text-gray-400">
-                Default: ws://127.0.0.1:28257 (leave empty to use default)
+                WebSocket server address for packet data reception
               </p>
             </div>
           </div>
@@ -173,12 +172,11 @@ export function SettingsPage() {
               <textarea
                 value={configs.ecapture_args || ''}
                 onChange={(e) => updateConfigs({ ecapture_args: e.target.value })}
-                placeholder="--interface=eth0 --port=8080"
                 rows={3}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 font-mono text-sm"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 font-mono text-sm"
               />
               <p className="text-xs text-gray-500 dark:text-gray-400">
-                Optional: Additional arguments to pass to the eCapture binary
+                Additional command line arguments for the eCapture process
               </p>
             </div>
           </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -141,10 +141,11 @@ export function SettingsPage() {
                 type="text"
                 value={configs.ws_url || ''}
                 onChange={(e) => updateConfigs({ ws_url: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                placeholder="ws://127.0.0.1:28257"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
               />
               <p className="text-xs text-gray-500 dark:text-gray-400">
-                WebSocket server address for packet data reception
+                Default: ws://127.0.0.1:28257 (leave empty to use default)
               </p>
             </div>
           </div>
@@ -172,11 +173,12 @@ export function SettingsPage() {
               <textarea
                 value={configs.ecapture_args || ''}
                 onChange={(e) => updateConfigs({ ecapture_args: e.target.value })}
+                placeholder="--interface=eth0 --port=8080"
                 rows={3}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 font-mono text-sm"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 font-mono text-sm"
               />
               <p className="text-xs text-gray-500 dark:text-gray-400">
-                Additional command line arguments for the eCapture process
+                Optional: Additional arguments to pass to the eCapture binary
               </p>
             </div>
           </div>


### PR DESCRIPTION
- Load settings from `config.json` on application startup.
- Create a default config file if one doesn't exist or is invalid.
- Save changes made via `modify_configs` command back to the file.
- Refactor app state and startup sequence to support async config loading.