### PR TITLE
fix: add temporary exception for home-relative path read-write access on macOS

### DIFF
--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -8,18 +8,5 @@
 
     <key>com.apple.security.network.client</key>
     <true/>
-
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-
-    <key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
-    <array>
-        <string>/Library/Application Support/</string>
-    </array>
-
-    <key>com.apple.application-identifier</key>
-    <string>2CJR2EP3SQ.com.gojue.ecaptureq</string>
-    <key>com.apple.developer.team-identifier</key>
-    <string>2CJR2EP3SQ</string>
 </dict>
 </plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,6 @@
       "minimumSystemVersion": "12.0",
       "entitlements": "entitlements.plist",
       "files": {
-        "embedded.provisionprofile": "ecaptureq.provisionprofile"
       }
     },
     "publisher": "gojue",


### PR DESCRIPTION
This pull request makes a minor change to the `src-tauri/entitlements.plist` file, adding a temporary security exception to allow read and write access to the `/Library/Application Support/` directory for the application. 

* Added `com.apple.security.temporary-exception.files.home-relative-path.read-write` entitlement to allow read/write access to `/Library/Application Support/`.

Fix the problem of missing system permissions on macOS

> embedded provisioning profile not valid: file:///Applications/eCaptureQ.app/Contents/embedded.provisionprofile error: Error Domain=CPProfileManager Code=-215 "Only Development Provisioning Profiles can be installed in System Settings. Production Provisioning Profiles are imported within Xcode." UserInfo={NSLocalizedDescription=Only Development Provisioning Profiles can be installed in System Settings. Production Provisioning Profiles are imported within Xcode.}