### PR TITLE
fix: remove draft option from GitHub release action in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,6 @@ jobs:
         if: matrix.platform == 'android'
         uses: softprops/action-gh-release@v1
         with:
-          draft: true
           name: eCaptureQ v${{ needs.pre_release.outputs.version }}
           tag_name: v${{ needs.pre_release.outputs.version }}
           files: ./eCaptureQ_${{ needs.pre_release.outputs.version }}_${{ matrix.arch }}.apk


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions release workflow by removing the `draft: true` setting from the Android release job. This means releases will no longer be created as drafts and will be published immediately.